### PR TITLE
Allow setting custom public key for checksum verification

### DIFF
--- a/checkpoint/latest_version.go
+++ b/checkpoint/latest_version.go
@@ -12,6 +12,7 @@ import (
 
 	checkpoint "github.com/hashicorp/go-checkpoint"
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hc-install/internal/pubkey"
 	rjson "github.com/hashicorp/hc-install/internal/releasesjson"
 	isrc "github.com/hashicorp/hc-install/internal/src"
 	"github.com/hashicorp/hc-install/product"
@@ -29,6 +30,10 @@ type LatestVersion struct {
 	Timeout                  time.Duration
 	SkipChecksumVerification bool
 	InstallDir               string
+
+	// ArmoredPublicKey is a public PGP key in ASCII/armor format to use
+	// instead of built-in pubkey to verify signature of downloaded checksums
+	ArmoredPublicKey string
 
 	logger        *log.Logger
 	pathsToRemove []string
@@ -109,8 +114,12 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	}
 
 	d := &rjson.Downloader{
-		Logger:         lv.log(),
-		VerifyChecksum: !lv.SkipChecksumVerification,
+		Logger:           lv.log(),
+		VerifyChecksum:   !lv.SkipChecksumVerification,
+		ArmoredPublicKey: pubkey.DefaultPublicKey,
+	}
+	if lv.ArmoredPublicKey != "" {
+		d.ArmoredPublicKey = lv.ArmoredPublicKey
 	}
 	err = d.DownloadAndUnpack(ctx, pv, dstDir)
 	if err != nil {

--- a/internal/pubkey/pubkey.go
+++ b/internal/pubkey/pubkey.go
@@ -1,9 +1,8 @@
-package releasesjson
+package pubkey
 
 const (
 	// See https://www.hashicorp.com/security
-	keyID     = `72D7468F`
-	publicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
+	DefaultPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----
 
 mQINBGB9+xkBEACabYZOWKmgZsHTdRDiyPJxhbuUiKX65GUWkyRMJKi/1dviVxOX
 PG6hBPtF48IFnVgxKpIb7G6NjBousAV+CuLlv5yqFKpOZEGC6sBV+Gx8Vu1CICpl

--- a/releases/versions.go
+++ b/releases/versions.go
@@ -17,10 +17,22 @@ type Versions struct {
 	Product     product.Product
 	Constraints version.Constraints
 
-	ListTimeout              time.Duration
-	InstallTimeout           time.Duration
-	InstallDir               string
+	ListTimeout time.Duration
+
+	// Install represents configuration for installation of any listed version
+	Install InstallationOptions
+}
+
+type InstallationOptions struct {
+	Timeout time.Duration
+	Dir     string
+
 	SkipChecksumVerification bool
+
+	// ArmoredPublicKey is a public PGP key in ASCII/armor format to use
+	// instead of built-in pubkey to verify signature of downloaded checksums
+	// during installation
+	ArmoredPublicKey string
 }
 
 func (v *Versions) List(ctx context.Context) ([]src.Source, error) {
@@ -56,10 +68,11 @@ func (v *Versions) List(ctx context.Context) ([]src.Source, error) {
 		ev := &ExactVersion{
 			Product:    v.Product,
 			Version:    installableVersion,
-			InstallDir: v.InstallDir,
-			Timeout:    v.InstallTimeout,
+			InstallDir: v.Install.Dir,
+			Timeout:    v.Install.Timeout,
 
-			SkipChecksumVerification: v.SkipChecksumVerification,
+			ArmoredPublicKey:         v.Install.ArmoredPublicKey,
+			SkipChecksumVerification: v.Install.SkipChecksumVerification,
 		}
 
 		installables = append(installables, ev)


### PR DESCRIPTION
As discussed previously this patch:

1. enables users to rotate the pubkey quickly without having to wait for upstream library update which would update the built-in key; key can also be provided from ENV variable in downstream if downstream chooses to use `os.Getenv` and passes that string to us
2. paves the way for us to eventually obtain the pubkey dynamically from keyserver at some point
