### PR TITLE
Fix GitHub Actions config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,8 @@ jobs:
 
     - name: Go fmt
       run: |
-        gofmt -s -l .
+        # exit 1 if any files need go fmt
+        test -z $(gofmt -s -l .)
 
     - name: Go vet
       run: |


### PR DESCRIPTION
CI was not running on PRs due to a syntax error in the GitHub Actions config.