### PR TITLE
fix: avoid crash in installer

### DIFF
--- a/installer.go
+++ b/installer.go
@@ -42,7 +42,7 @@ func (i *Installer) Ensure(ctx context.Context, sources []src.Source) (string, e
 		}
 	}
 
-	if len(errs.Errors) > 0 {
+	if errs.ErrorOrNil() != nil {
 		return "", errs
 	}
 


### PR DESCRIPTION
This was just an oversight on my part in how multierror is supposed to be used.

When no error is appended, the variable remains `nil` and therefore attempting to access any of its fields will crash.