### PR TITLE
product: bump consul clone timeout

### DIFF
--- a/product/consul.go
+++ b/product/consul.go
@@ -52,6 +52,7 @@ var Consul = Product{
 	},
 	BuildInstructions: &BuildInstructions{
 		GitRepoURL:    "https://github.com/hashicorp/consul.git",
+		CloneTimeout:  2 * time.Minute,
 		PreCloneCheck: &build.GoIsInstalled{},
 		Build:         &build.GoBuild{Version: v1_16},
 		BuildTimeout:  8 * time.Minute,


### PR DESCRIPTION
It seems that we were recently unable to clone the consul repo in our E2E tests under the default 1 minute timeout:

```
2021/11/10 22:11:00 git_revision.go:123: cloning consul repository from https://github.com/hashicorp/consul.git to /tmp/hc-install-build-consul1492782617 (timeout: 1m0s)
    git_revision_test.go:58: unable to clone consul from "https://github.com/hashicorp/consul.git": context deadline exceeded
--- FAIL: TestGitRevision_consul (61.65s)
```