### PR TITLE
product: revise default clone & build timeouts

### DIFF
--- a/build/git_revision.go
+++ b/build/git_revision.go
@@ -17,8 +17,8 @@ import (
 
 var (
 	defaultPreCloneCheckTimeout = 1 * time.Minute
-	defaultCloneTimeout         = 1 * time.Minute
-	defaultBuildTimeout         = 5 * time.Minute
+	defaultCloneTimeout         = 2 * time.Minute
+	defaultBuildTimeout         = 10 * time.Minute
 
 	discardLogger = log.New(ioutil.Discard, "", 0)
 )

--- a/product/consul.go
+++ b/product/consul.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/internal/build"
@@ -52,9 +51,7 @@ var Consul = Product{
 	},
 	BuildInstructions: &BuildInstructions{
 		GitRepoURL:    "https://github.com/hashicorp/consul.git",
-		CloneTimeout:  2 * time.Minute,
 		PreCloneCheck: &build.GoIsInstalled{},
 		Build:         &build.GoBuild{Version: v1_16},
-		BuildTimeout:  10 * time.Minute,
 	},
 }


### PR DESCRIPTION
After seeing that Terraform already takes around 30-40 seconds on average to clone and close to 5 mins to build in GHA environment I decided to just raise the default timeouts.

https://github.com/hashicorp/hc-install/runs/4177083536?check_suite_focus=true#step:5:18