### PR TITLE
installer: align Install with Ensure & test it

### DIFF
--- a/installer_test.go
+++ b/installer_test.go
@@ -33,3 +33,27 @@ func TestInstaller_Ensure(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestInstaller_Install(t *testing.T) {
+	testutil.EndToEndTest(t)
+
+	// most of this logic is already tested within individual packages
+	// so this is just a simple E2E test to ensure the public API
+	// also works and continues working
+
+	i := NewInstaller()
+	i.SetLogger(testutil.TestLogger())
+	ctx := context.Background()
+	_, err := i.Install(ctx, []src.Installable{
+		&releases.LatestVersion{
+			Product: product.Terraform,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = i.Remove(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/hc-install/issues/25

The two main methods (`Ensure` and `Install`) have inconsistent behaviour in the sense that `Install` doesn't perform validation or track installed files such that they can be removed.

This PR aligns both methods.

While reading this code I also realized that we make (somewhat unconscious) assumption that the state (removable files) only survives until the next `Ensure` or `Install` call, so the user can't really call both or one of those repeatedly, unless they also always call `Remove` before. I created a separate issue to track that though: https://github.com/hashicorp/hc-install/issues/35