### PR TITLE
fs: Fixes and unit testing for (AnyVersion).Validate()

### DIFF
--- a/fs/any_version.go
+++ b/fs/any_version.go
@@ -43,13 +43,16 @@ func (*AnyVersion) IsSourceImpl() src.InstallSrcSigil {
 }
 
 func (av *AnyVersion) Validate() error {
+	if av.ExactBinPath == "" && av.Product == nil {
+		return fmt.Errorf("must use either ExactBinPath or Product + ExtraPaths")
+	}
 	if av.ExactBinPath != "" && (av.Product != nil || len(av.ExtraPaths) > 0) {
 		return fmt.Errorf("use either ExactBinPath or Product + ExtraPaths, not both")
 	}
-	if !filepath.IsAbs(av.ExactBinPath) {
+	if av.ExactBinPath != "" && !filepath.IsAbs(av.ExactBinPath) {
 		return fmt.Errorf("expected ExactBinPath (%q) to be an absolute path", av.ExactBinPath)
 	}
-	if !validators.IsBinaryNameValid(av.Product.BinaryName()) {
+	if av.Product != nil && !validators.IsBinaryNameValid(av.Product.BinaryName()) {
 		return fmt.Errorf("invalid binary name: %q", av.Product.BinaryName())
 	}
 	return nil

--- a/fs/any_version_test.go
+++ b/fs/any_version_test.go
@@ -1,0 +1,82 @@
+package fs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hc-install/product"
+)
+
+func TestAnyVersionValidate(t *testing.T) {
+	t.Parallel()
+
+	productWithInvalidBinaryName := product.Terraform
+	productWithInvalidBinaryName.BinaryName = func() string { return "invalid!" }
+
+	testCases := map[string]struct {
+		av          AnyVersion
+		expectedErr error
+	}{
+		"no-fields-set": {
+			av:          AnyVersion{},
+			expectedErr: fmt.Errorf("must use either ExactBinPath or Product + ExtraPaths"),
+		},
+		"ExactBinPath-and-Product": {
+			av: AnyVersion{
+				ExactBinPath: "/test",
+				Product:      &product.Terraform,
+			},
+			expectedErr: fmt.Errorf("use either ExactBinPath or Product + ExtraPaths, not both"),
+		},
+		"ExactBinPath-empty": {
+			av: AnyVersion{
+				ExactBinPath: "",
+			},
+			expectedErr: fmt.Errorf("must use either ExactBinPath or Product + ExtraPaths"),
+		},
+		"ExactBinPath-relative": {
+			av: AnyVersion{
+				ExactBinPath: "test",
+			},
+			expectedErr: fmt.Errorf("expected ExactBinPath (\"test\") to be an absolute path"),
+		},
+		"ExactBinPath-absolute": {
+			av: AnyVersion{
+				ExactBinPath: "/test",
+			},
+		},
+		"Product-incorrect-binary-name": {
+			av: AnyVersion{
+				Product: &productWithInvalidBinaryName,
+			},
+			expectedErr: fmt.Errorf("invalid binary name: %q", productWithInvalidBinaryName.BinaryName()),
+		},
+		"Product-valid": {
+			av: AnyVersion{
+				Product: &product.Terraform,
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.av.Validate()
+
+			if err == nil && testCase.expectedErr != nil {
+				t.Fatalf("expected error: %s, got no error", testCase.expectedErr)
+			}
+
+			if err != nil && testCase.expectedErr == nil {
+				t.Fatalf("expected no error, got error: %s", err)
+			}
+
+			if err != nil && testCase.expectedErr != nil && err.Error() != testCase.expectedErr.Error() {
+				t.Fatalf("expected error: %s, got error: %s", testCase.expectedErr, err)
+			}
+		})
+	}
+}

--- a/fs/any_version_test.go
+++ b/fs/any_version_test.go
@@ -40,7 +40,7 @@ func TestAnyVersionValidate(t *testing.T) {
 		},
 		"ExactBinPath-absolute": {
 			av: AnyVersion{
-				ExactBinPath: string(filepath.Separator) + "test",
+				ExactBinPath: filepath.Join(t.TempDir(), "test"),
 			},
 		},
 		"Product-incorrect-binary-name": {

--- a/fs/any_version_test.go
+++ b/fs/any_version_test.go
@@ -42,7 +42,7 @@ func TestAnyVersionValidate(t *testing.T) {
 		},
 		"ExactBinPath-absolute": {
 			av: AnyVersion{
-				ExactBinPath: "/test",
+				ExactBinPath: filepath.Separator + "test",
 			},
 		},
 		"Product-incorrect-binary-name": {

--- a/fs/any_version_test.go
+++ b/fs/any_version_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/hc-install/product"
@@ -9,9 +10,6 @@ import (
 
 func TestAnyVersionValidate(t *testing.T) {
 	t.Parallel()
-
-	productWithInvalidBinaryName := product.Terraform
-	productWithInvalidBinaryName.BinaryName = func() string { return "invalid!" }
 
 	testCases := map[string]struct {
 		av          AnyVersion
@@ -42,14 +40,17 @@ func TestAnyVersionValidate(t *testing.T) {
 		},
 		"ExactBinPath-absolute": {
 			av: AnyVersion{
-				ExactBinPath: filepath.Separator + "test",
+				ExactBinPath: string(filepath.Separator) + "test",
 			},
 		},
 		"Product-incorrect-binary-name": {
 			av: AnyVersion{
-				Product: &productWithInvalidBinaryName,
+				Product: &product.Product{
+					BinaryName: func() string { return "invalid!" },
+					Name:       product.Terraform.Name,
+				},
 			},
-			expectedErr: fmt.Errorf("invalid binary name: %q", productWithInvalidBinaryName.BinaryName()),
+			expectedErr: fmt.Errorf("invalid binary name: \"invalid!\""),
 		},
 		"Product-valid": {
 			av: AnyVersion{


### PR DESCRIPTION
Previously, if `Product` was specified, but not `ExactBinPath`, the following error was returned:

```
1 error occurred:
        * expected ExactBinPath ("") to be an absolute path
```