### PR TITLE
installer: Add top-level E2E test for fs.AnyVersion

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -3,8 +3,6 @@ package fs
 import (
 	"context"
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -42,26 +40,4 @@ func TestExactVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-func createTempFile(t *testing.T, content string) (string, string) {
-	tmpDir := t.TempDir()
-	fileName := t.Name()
-
-	if runtime.GOOS == "windows" {
-		fileName += ".exe"
-	}
-
-	filePath := filepath.Join(tmpDir, fileName)
-	f, err := os.Create(filePath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close()
-	_, err = f.WriteString(content)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return tmpDir, fileName
 }

--- a/fs/fs_unix_test.go
+++ b/fs/fs_unix_test.go
@@ -23,7 +23,7 @@ func TestAnyVersion_notExecutable(t *testing.T) {
 		os.Setenv("PATH", originalPath)
 	})
 
-	dirPath, fileName := createTempFile(t, "")
+	dirPath, fileName := testutil.CreateTempFile(t, "")
 	os.Setenv("PATH", dirPath)
 
 	av := &AnyVersion{
@@ -47,7 +47,7 @@ func TestAnyVersion_executable(t *testing.T) {
 		os.Setenv("PATH", originalPath)
 	})
 
-	dirPath, fileName := createTempFile(t, "")
+	dirPath, fileName := testutil.CreateTempFile(t, "")
 	os.Setenv("PATH", dirPath)
 
 	fullPath := filepath.Join(dirPath, fileName)
@@ -71,7 +71,7 @@ func TestAnyVersion_executable(t *testing.T) {
 func TestAnyVersion_exactBinPath(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	dirPath, fileName := createTempFile(t, "")
+	dirPath, fileName := testutil.CreateTempFile(t, "")
 	fullPath := filepath.Join(dirPath, fileName)
 	err := os.Chmod(fullPath, 0700)
 	if err != nil {
@@ -91,7 +91,7 @@ func TestAnyVersion_exactBinPath(t *testing.T) {
 func TestAnyVersion_exactBinPath_notExecutable(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	dirPath, fileName := createTempFile(t, "")
+	dirPath, fileName := testutil.CreateTempFile(t, "")
 	fullPath := filepath.Join(dirPath, fileName)
 	err := os.Chmod(fullPath, 0600)
 	if err != nil {

--- a/fs/fs_windows_test.go
+++ b/fs/fs_windows_test.go
@@ -20,7 +20,7 @@ func TestAnyVersion_executable(t *testing.T) {
 		os.Setenv("path", originalPath)
 	})
 
-	dirPath, fileName := createTempFile(t, "")
+	dirPath, fileName := testutil.CreateTempFile(t, "")
 	os.Setenv("path", dirPath)
 
 	av := &AnyVersion{
@@ -38,7 +38,7 @@ func TestAnyVersion_executable(t *testing.T) {
 func TestAnyVersion_exactBinPath(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	dirPath, fileName := createTempFile(t, "")
+	dirPath, fileName := testutil.CreateTempFile(t, "")
 	fullPath := filepath.Join(dirPath, fileName)
 
 	av := &AnyVersion{
@@ -54,7 +54,7 @@ func TestAnyVersion_exactBinPath(t *testing.T) {
 func TestAnyVersion_exactBinPath_notFound(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	dirPath, fileName := createTempFile(t, "")
+	dirPath, fileName := testutil.CreateTempFile(t, "")
 	fullPath := filepath.Join(dirPath, fileName)
 
 	err := os.Remove(fullPath)

--- a/installer_test.go
+++ b/installer_test.go
@@ -39,14 +39,8 @@ func TestInstaller_Ensure_installable(t *testing.T) {
 func TestInstaller_Ensure_findable(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	originalPath := os.Getenv("PATH")
-	os.Setenv("PATH", "")
-	t.Cleanup(func() {
-		os.Setenv("PATH", originalPath)
-	})
-
 	dirPath, fileName := testutil.CreateTempFile(t, "")
-	os.Setenv("PATH", dirPath)
+	t.Setenv("PATH", dirPath)
 
 	// most of this logic is already tested within individual packages
 	// so this is just a simple E2E test to ensure the public API

--- a/installer_test.go
+++ b/installer_test.go
@@ -2,7 +2,6 @@ package install
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/hc-install/fs"

--- a/installer_test.go
+++ b/installer_test.go
@@ -2,6 +2,8 @@ package install
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/hc-install/fs"
@@ -39,6 +41,13 @@ func TestInstaller_Ensure_findable(t *testing.T) {
 	testutil.EndToEndTest(t)
 
 	dirPath, fileName := testutil.CreateTempFile(t, "")
+
+	fullPath := filepath.Join(dirPath, fileName)
+	err := os.Chmod(fullPath, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Setenv("PATH", dirPath)
 
 	// most of this logic is already tested within individual packages
@@ -48,7 +57,7 @@ func TestInstaller_Ensure_findable(t *testing.T) {
 	i := NewInstaller()
 	i.SetLogger(testutil.TestLogger())
 	ctx := context.Background()
-	_, err := i.Ensure(ctx, []src.Source{
+	_, err = i.Ensure(ctx, []src.Source{
 		&fs.AnyVersion{
 			Product: &product.Product{
 				BinaryName: func() string {

--- a/internal/testutil/temp_file.go
+++ b/internal/testutil/temp_file.go
@@ -1,0 +1,30 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func CreateTempFile(t *testing.T, content string) (string, string) {
+	tmpDir := t.TempDir()
+	fileName := t.Name()
+
+	if runtime.GOOS == "windows" {
+		fileName += ".exe"
+	}
+
+	filePath := filepath.Join(tmpDir, fileName)
+	f, err := os.Create(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	_, err = f.WriteString(content)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpDir, fileName
+}


### PR DESCRIPTION
Validators should be tested either way separately, but `fs.AnyVersion` seems like a common enough use case that it's worth testing it also from the top-level API perspective.

The failing test is being fixed in #42 