### PR TITLE
fs: Replace os.Setenv() usage in testing with (testing.T).Setenv()

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -27,11 +27,7 @@ func TestExactVersion(t *testing.T) {
 
 	// TODO: mock out command execution?
 
-	originalPath := os.Getenv("PATH")
-	os.Setenv("PATH", "")
-	t.Cleanup(func() {
-		os.Setenv("PATH", originalPath)
-	})
+	t.Setenv("PATH", "")
 
 	ev := &ExactVersion{
 		Product: product.Terraform,

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/go-version"

--- a/fs/fs_unix_test.go
+++ b/fs/fs_unix_test.go
@@ -17,14 +17,8 @@ import (
 func TestAnyVersion_notExecutable(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	originalPath := os.Getenv("PATH")
-	os.Setenv("PATH", "")
-	t.Cleanup(func() {
-		os.Setenv("PATH", originalPath)
-	})
-
 	dirPath, fileName := createTempFile(t, "")
-	os.Setenv("PATH", dirPath)
+	t.Setenv("PATH", dirPath)
 
 	av := &AnyVersion{
 		Product: &product.Product{
@@ -41,14 +35,8 @@ func TestAnyVersion_notExecutable(t *testing.T) {
 func TestAnyVersion_executable(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	originalPath := os.Getenv("PATH")
-	os.Setenv("PATH", "")
-	t.Cleanup(func() {
-		os.Setenv("PATH", originalPath)
-	})
-
 	dirPath, fileName := createTempFile(t, "")
-	os.Setenv("PATH", dirPath)
+	t.Setenv("PATH", dirPath)
 
 	fullPath := filepath.Join(dirPath, fileName)
 	err := os.Chmod(fullPath, 0700)

--- a/fs/fs_windows_test.go
+++ b/fs/fs_windows_test.go
@@ -14,14 +14,8 @@ import (
 func TestAnyVersion_executable(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	originalPath := os.Getenv("path")
-	os.Setenv("path", "")
-	t.Cleanup(func() {
-		os.Setenv("path", originalPath)
-	})
-
 	dirPath, fileName := createTempFile(t, "")
-	os.Setenv("path", dirPath)
+	t.Setenv("path", dirPath)
 
 	av := &AnyVersion{
 		Product: &product.Product{


### PR DESCRIPTION
Reference: https://pkg.go.dev/testing#T.Setenv

Added in Go 1.17. It will automatically reset the environment variable after each test.