### PR TITLE
ci: bump timeout for E2E tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     name: Test
     needs: build
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -68,8 +68,8 @@ jobs:
         go test -v -race ./...
 
     - name: E2E tests
-      timeout-minutes: 15
+      timeout-minutes: 20
       env:
         E2E_TESTING: 1
       run: |
-        go test -timeout=15m -v ./...
+        go test -timeout=20m -v ./...


### PR DESCRIPTION
This is to address the recent timeout:

https://github.com/hashicorp/hc-install/runs/5285804883?check_suite_focus=true#step:5:337

The test which varies the most is apparently _building_ - effectively `go build` on macOS. I'm unsure why that is, given that this only depends on the local CPU/memory (not network) - it could be some hardware issues on GitHub's side 🤔 
`TestGitRevision_consul` took `744.15s` last time but also `415.35s` before.

https://github.com/hashicorp/hc-install/runs/5285804883?check_suite_focus=true#step:5:57