### PR TITLE
`fs.AnyVersion` supports optional version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ execPath, err := i.Ensure(context.Background(), []src.Source{
     Product: product.Terraform,
     Version: v0_14_0,
   },
+  &fs.AnyVersion{
+    Product: product.Terraform,
+    Constraint: "~> 0.14.0",
+  },
   &releases.ExactVersion{
     Product: product.Terraform,
     Version: v0_14_0,

--- a/fs/any_version_test.go
+++ b/fs/any_version_test.go
@@ -52,9 +52,31 @@ func TestAnyVersionValidate(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("invalid binary name: \"invalid!\""),
 		},
+		"Product-with-constraint-missing-get-version": {
+			av: AnyVersion{
+				Product: &product.Product{
+					BinaryName: product.Terraform.BinaryName,
+				},
+				Constraint: ">= 1.0",
+			},
+			expectedErr: fmt.Errorf("undeclared version getter"),
+		},
+		"Product-incorrect-constraint": {
+			av: AnyVersion{
+				Product:    &product.Terraform,
+				Constraint: "invalid!",
+			},
+			expectedErr: fmt.Errorf(`Malformed constraint: invalid!`),
+		},
 		"Product-valid": {
 			av: AnyVersion{
 				Product: &product.Terraform,
+			},
+		},
+		"Product-with-constraint-valid": {
+			av: AnyVersion{
+				Product:    &product.Terraform,
+				Constraint: ">= 1.0",
 			},
 		},
 	}

--- a/fs/fs_unix_test.go
+++ b/fs/fs_unix_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hc-install/errors"
 	"github.com/hashicorp/hc-install/internal/testutil"
 	"github.com/hashicorp/hc-install/product"
@@ -53,6 +54,66 @@ func TestAnyVersion_executable(t *testing.T) {
 	_, err = av.Find(context.Background())
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAnyVersion_constraint(t *testing.T) {
+	testutil.EndToEndTest(t)
+
+	dirPath, fileName := testutil.CreateTempFile(t, "")
+	t.Setenv("PATH", dirPath)
+
+	fullPath := filepath.Join(dirPath, fileName)
+	err := os.Chmod(fullPath, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	av := &AnyVersion{
+		Product: &product.Product{
+			BinaryName: func() string { return fileName },
+			GetVersion: func(ctx context.Context, execPath string) (*version.Version, error) {
+				return version.NewVersion("1.2.0")
+			},
+		},
+		Constraint: "~> 1.0",
+	}
+	av.SetLogger(testutil.TestLogger())
+	_, err = av.Find(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnyVersion_constraintNotMet(t *testing.T) {
+	testutil.EndToEndTest(t)
+
+	dirPath, fileName := testutil.CreateTempFile(t, "")
+	t.Setenv("PATH", dirPath)
+
+	fullPath := filepath.Join(dirPath, fileName)
+	err := os.Chmod(fullPath, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	av := &AnyVersion{
+		Product: &product.Product{
+			BinaryName: func() string { return fileName },
+			GetVersion: func(ctx context.Context, execPath string) (*version.Version, error) {
+				return version.NewVersion("2.0.0")
+			},
+		},
+		Constraint: "~> 1.0",
+	}
+	av.SetLogger(testutil.TestLogger())
+	_, err = av.Find(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-executable file")
+	}
+
+	if !errors.IsErrorSkippable(err) {
+		t.Fatalf("expected a skippable error, got: %#v", err)
 	}
 }
 


### PR DESCRIPTION
Allows users to optionally specify one or more (comma separated) version constraints for `fs.AnyVersion` source.