### PR TITLE
Support releases-api returned content-type

### DIFF
--- a/internal/releasesjson/releases.go
+++ b/internal/releasesjson/releases.go
@@ -79,7 +79,7 @@ func (r *Releases) ListProductVersions(ctx context.Context, productName string) 
 	}
 
 	contentType := resp.Header.Get("content-type")
-	if contentType != "application/json" {
+	if contentType != "application/json" && contentType != "application/vnd+hashicorp.releases-api.v0+json" {
 		return nil, fmt.Errorf("unexpected Content-Type: %q", contentType)
 	}
 
@@ -144,7 +144,7 @@ func (r *Releases) GetProductVersion(ctx context.Context, product string, versio
 	}
 
 	contentType := resp.Header.Get("content-type")
-	if contentType != "application/json" {
+	if contentType != "application/json" && contentType != "application/vnd+hashicorp.releases-api.v0+json" {
 		return nil, fmt.Errorf("unexpected Content-Type: %q", contentType)
 	}
 

--- a/product/consul.go
+++ b/product/consul.go
@@ -18,6 +18,7 @@ var (
 	v1_16 = version.Must(version.NewVersion("1.16"))
 	// TODO: version.MustConstraint() ?
 	v1_16c, _ = version.NewConstraint("1.16")
+	v1_18     = version.Must(version.NewVersion("1.18"))
 )
 
 var Consul = Product{
@@ -52,6 +53,6 @@ var Consul = Product{
 	BuildInstructions: &BuildInstructions{
 		GitRepoURL:    "https://github.com/hashicorp/consul.git",
 		PreCloneCheck: &build.GoIsInstalled{},
-		Build:         &build.GoBuild{Version: v1_16},
+		Build:         &build.GoBuild{Version: v1_18},
 	},
 }

--- a/product/consul.go
+++ b/product/consul.go
@@ -15,10 +15,7 @@ import (
 var consulVersionOutputRe = regexp.MustCompile(`Consul ` + simpleVersionRe)
 
 var (
-	v1_16 = version.Must(version.NewVersion("1.16"))
-	// TODO: version.MustConstraint() ?
-	v1_16c, _ = version.NewConstraint("1.16")
-	v1_18     = version.Must(version.NewVersion("1.18"))
+	v1_18 = version.Must(version.NewVersion("1.18"))
 )
 
 var Consul = Product{


### PR DESCRIPTION
Update the content-type checks to include the type returned from the releases api.

*Edit*: Also set Go version to 1.18 when building Consul from source. 

Closes #56 

Signed-off-by: Scott Macfarlane <smacfarlane@hashicorp.com>