### PR TITLE
build: bump default clone timeout from 2 to 5 mins

### DIFF
--- a/build/git_revision.go
+++ b/build/git_revision.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	defaultPreCloneCheckTimeout = 1 * time.Minute
-	defaultCloneTimeout         = 2 * time.Minute
+	defaultCloneTimeout         = 5 * time.Minute
 	defaultBuildTimeout         = 10 * time.Minute
 
 	discardLogger = log.New(ioutil.Discard, "", 0)


### PR DESCRIPTION
Terraform builds in particular started timing out recently in tfexec nightly tests.

https://app.circleci.com/pipelines/github/hashicorp/terraform-exec/1700/workflows/32189069-fab5-4884-bff7-6730fe6f625b/jobs/19137/steps

https://app.circleci.com/pipelines/github/hashicorp/terraform-exec/1695/workflows/a545d643-0365-44b0-ab87-d154936a9098/jobs/19097

The original 2min timeout is quite conservative IMO, and 5mins won't do much harm. The main purpose of these timeouts is to avoid waiting forever when there's network problems anyway.