### PR TITLE
installer: Allow context propagation to reach http requests

### DIFF
--- a/internal/releasesjson/checksum_downloader.go
+++ b/internal/releasesjson/checksum_downloader.go
@@ -83,7 +83,7 @@ func (cd *ChecksumDownloader) downloadAndVerifyChecksums(ctx context.Context) (C
 		url.PathEscape(cd.ProductVersion.SHASUMS))
 	cd.Logger.Printf("downloading checksums from %s", shasumsURL)
 
-	req, err = http.NewRequest(http.MethodGet, sigURL, nil)
+	req, err = http.NewRequest(http.MethodGet, shasumsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %q: %w", shasumsURL, err)
 	}

--- a/internal/releasesjson/checksum_downloader.go
+++ b/internal/releasesjson/checksum_downloader.go
@@ -57,11 +57,10 @@ func (cd *ChecksumDownloader) DownloadAndVerifyChecksums(ctx context.Context) (C
 		url.PathEscape(sigFilename))
 	cd.Logger.Printf("downloading signature from %s", sigURL)
 
-	req, err := http.NewRequest(http.MethodGet, sigURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sigURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %q: %w", sigURL, err)
 	}
-	req = req.WithContext(ctx)
 	sigResp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -79,11 +78,10 @@ func (cd *ChecksumDownloader) DownloadAndVerifyChecksums(ctx context.Context) (C
 		url.PathEscape(cd.ProductVersion.SHASUMS))
 	cd.Logger.Printf("downloading checksums from %s", shasumsURL)
 
-	req, err = http.NewRequest(http.MethodGet, shasumsURL, nil)
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, shasumsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %q: %w", shasumsURL, err)
 	}
-	req = req.WithContext(ctx)
 	sumsResp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/internal/releasesjson/checksum_downloader.go
+++ b/internal/releasesjson/checksum_downloader.go
@@ -44,11 +44,7 @@ func HashSumFromHexDigest(hexDigest string) (HashSum, error) {
 	return HashSum(sumBytes), nil
 }
 
-func (cd *ChecksumDownloader) DownloadAndVerifyChecksums() (ChecksumFileMap, error) {
-	return cd.downloadAndVerifyChecksums(context.Background())
-}
-
-func (cd *ChecksumDownloader) downloadAndVerifyChecksums(ctx context.Context) (ChecksumFileMap, error) {
+func (cd *ChecksumDownloader) DownloadAndVerifyChecksums(ctx context.Context) (ChecksumFileMap, error) {
 	sigFilename, err := cd.findSigFilename(cd.ProductVersion)
 	if err != nil {
 		return nil, err

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -43,7 +43,7 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 			Logger:           d.Logger,
 			ArmoredPublicKey: d.ArmoredPublicKey,
 		}
-		verifiedChecksums, err := v.downloadAndVerifyChecksums(ctx)
+		verifiedChecksums, err := v.DownloadAndVerifyChecksums(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -76,11 +76,10 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	d.Logger.Printf("downloading archive from %s", archiveURL)
 
-	req, err := http.NewRequest(http.MethodGet, archiveURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request for %q: %w", archiveURL, err)
 	}
-	req = req.WithContext(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -42,7 +43,7 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 			Logger:           d.Logger,
 			ArmoredPublicKey: d.ArmoredPublicKey,
 		}
-		verifiedChecksums, err := v.DownloadAndVerifyChecksums()
+		verifiedChecksums, err := v.downloadAndVerifyChecksums(ctx)
 		if err != nil {
 			return err
 		}
@@ -74,7 +75,13 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 	}
 
 	d.Logger.Printf("downloading archive from %s", archiveURL)
-	resp, err := client.Get(archiveURL)
+
+	req, err := http.NewRequest(http.MethodGet, archiveURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for %q: %w", archiveURL, err)
+	}
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/releasesjson/releases.go
+++ b/internal/releasesjson/releases.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -68,7 +69,12 @@ func (r *Releases) ListProductVersions(ctx context.Context, productName string) 
 		url.PathEscape(productName))
 	r.logger.Printf("requesting versions from %s", productIndexURL)
 
-	resp, err := client.Get(productIndexURL)
+	req, err := http.NewRequest(http.MethodGet, productIndexURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %q: %w", productIndexURL, err)
+	}
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +139,12 @@ func (r *Releases) GetProductVersion(ctx context.Context, product string, versio
 		url.PathEscape(version.String()))
 	r.logger.Printf("requesting version from %s", indexURL)
 
-	resp, err := client.Get(indexURL)
+	req, err := http.NewRequest(http.MethodGet, indexURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for %q: %w", indexURL, err)
+	}
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/releasesjson/releases.go
+++ b/internal/releasesjson/releases.go
@@ -69,11 +69,10 @@ func (r *Releases) ListProductVersions(ctx context.Context, productName string) 
 		url.PathEscape(productName))
 	r.logger.Printf("requesting versions from %s", productIndexURL)
 
-	req, err := http.NewRequest(http.MethodGet, productIndexURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, productIndexURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %q: %w", productIndexURL, err)
 	}
-	req = req.WithContext(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -139,11 +138,10 @@ func (r *Releases) GetProductVersion(ctx context.Context, product string, versio
 		url.PathEscape(version.String()))
 	r.logger.Printf("requesting version from %s", indexURL)
 
-	req, err := http.NewRequest(http.MethodGet, indexURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, indexURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for %q: %w", indexURL, err)
 	}
-	req = req.WithContext(ctx)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/product/vault.go
+++ b/product/vault.go
@@ -14,7 +14,6 @@ import (
 
 var (
 	vaultVersionOutputRe = regexp.MustCompile(`Vault ` + simpleVersionRe)
-	v1_17                = version.Must(version.NewVersion("1.17"))
 )
 
 var Vault = Product{
@@ -49,6 +48,6 @@ var Vault = Product{
 	BuildInstructions: &BuildInstructions{
 		GitRepoURL:    "https://github.com/hashicorp/vault.git",
 		PreCloneCheck: &build.GoIsInstalled{},
-		Build:         &build.GoBuild{Version: v1_17},
+		Build:         &build.GoBuild{Version: v1_18},
 	},
 }


### PR DESCRIPTION
The `Install` method (e.g. `(*releases.ExactVersion).Install`) takes a context, then calls `GetProductVersion` and `DownloadAndUnpack`, however, all http requests done within these functions do not propagate the context. This PR allows for the context to propagate.
