### PR TITLE
ci: run E2E tests nightly

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -1,0 +1,30 @@
+name: Nightly E2E Tests
+
+on:
+  schedule:
+    - cron:  '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: E2E Tests
+    needs: build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
+
+    - name: E2E tests
+      timeout-minutes: 35
+      env:
+        E2E_TESTING: 1
+      run: |
+        go test -timeout=30m -v ./...


### PR DESCRIPTION
Depends on #76 

Closes #41 

We could/should also probably bump Go used in CI and for development (per `.go-version`) but I left that for a separate PR.