### PR TITLE
ci: bump actions versions & enable dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["dependencies"]

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.17'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.17'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Go fmt
       run: |
@@ -54,13 +54,13 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '1.17'
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Unit tests
       timeout-minutes: 5


### PR DESCRIPTION
This is to address the following warnings related to Node version:

https://github.com/hashicorp/hc-install/actions/runs/3487367151

<img width="867" alt="Screenshot 2022-12-01 at 08 28 07" src="https://user-images.githubusercontent.com/287584/205003424-0b95dfbe-00fe-49c4-a76b-3f11644dedc0.png">
