### PR TITLE
ci: fix nightly GHA workflow

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     name: E2E Tests
-    needs: build
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -16,7 +15,6 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:


### PR DESCRIPTION
> Invalid workflow file
> The workflow is not valid. .github/workflows/nightly-tests.yaml (Line: 9, Col: 3): The workflow must contain at least one job with no dependencies.