### PR TITLE
internal/build: Fix installation of some Go versions

### DIFF
--- a/build/git_revision.go
+++ b/build/git_revision.go
@@ -130,8 +130,8 @@ func (gr *GitRevision) Build(ctx context.Context) (string, error) {
 		Depth:         1,
 	})
 	if err != nil {
-		return "", fmt.Errorf("unable to clone %s from %q: %w",
-			gr.Product.Name, gr.Product.BuildInstructions.GitRepoURL, err)
+		return "", fmt.Errorf("unable to clone %s from %q @ %q: %w",
+			gr.Product.Name, gr.Product.BuildInstructions.GitRepoURL, ref, err)
 	}
 	gr.log().Printf("cloning %s finished", gr.Product.Name)
 	head, err := repo.Head()

--- a/internal/build/install_go_version.go
+++ b/internal/build/install_go_version.go
@@ -13,9 +13,10 @@ import (
 // installGoVersion installs given version of Go using Go
 // according to https://golang.org/doc/manage-install
 func (gb *GoBuild) installGoVersion(ctx context.Context, v *version.Version) (Go, error) {
-	// trim 0 patch versions as that's how Go does it :shrug:
-	shortVersion := strings.TrimSuffix(v.String(), ".0")
+	versionString := v.Core().String()
 
+	// trim 0 patch versions as that's how Go does it :shrug:
+	shortVersion := strings.TrimSuffix(versionString, ".0")
 	pkgURL := fmt.Sprintf("golang.org/dl/go%s", shortVersion)
 
 	gb.log().Printf("go getting %q", pkgURL)
@@ -27,13 +28,13 @@ func (gb *GoBuild) installGoVersion(ctx context.Context, v *version.Version) (Go
 
 	cmdName := fmt.Sprintf("go%s", shortVersion)
 
-	gb.log().Printf("downloading go %q", shortVersion)
+	gb.log().Printf("downloading go %q", v)
 	cmd = exec.CommandContext(ctx, cmdName, "download")
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		return Go{}, fmt.Errorf("unable to download Go %s: %w\n%s", v, err, out)
 	}
-	gb.log().Printf("download of go %q finished", shortVersion)
+	gb.log().Printf("download of go %q finished", v)
 
 	cleanupFunc := func(ctx context.Context) {
 		cmd = exec.CommandContext(ctx, cmdName, "env", "GOROOT")

--- a/internal/build/install_go_version.go
+++ b/internal/build/install_go_version.go
@@ -23,6 +23,13 @@ func (gb *GoBuild) installGoVersion(ctx context.Context, v *version.Version) (Go
 	cmd := exec.CommandContext(ctx, "go", "get", pkgURL)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
+		return Go{}, fmt.Errorf("unable to get Go %s: %w\n%s", v, err, out)
+	}
+
+	gb.log().Printf("go installing %q", pkgURL)
+	cmd = exec.CommandContext(ctx, "go", "install", pkgURL)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
 		return Go{}, fmt.Errorf("unable to install Go %s: %w\n%s", v, err, out)
 	}
 


### PR DESCRIPTION
Depends on https://github.com/hashicorp/hc-install/pull/86

--- 

On Go 1.18+, if we need to install Go, the installation results in the following error message

```
error installing terraform "gitref:refs/heads/main": unable to download Go 1.19.4: exec: "go1.19.4": executable file not found in $PATH
```

This is because we use `go get` to install Go, and since 1.18, the preferred methods is `go install`, `go get` no longer installs stuff: https://go.dev/doc/go-get-install-deprecation

This was discovered in https://github.com/hashicorp/terraform-exec/actions/runs/3873052889/jobs/6602632108#step:8:22

I'm on the edge of whether this needs to be tested, since it involves a lot of external calls.

--- 

This did not come up earlier because `terraform-exec` E2E nightly tests always ran on Go < 1.18.