### PR TITLE
ci: Run tests on Go 1.18 & 1.19

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -6,14 +6,41 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: E2E Tests
+  # resolve-versions allows us to show resolved Go versions in job titles
+  # for added clarity and quick orientation in a long list of past jobs
+  resolve-versions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      -
+        name: Resolve old stable version
+        id: oldstable
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
+        with:
+          go-version: oldstable
+      -
+        name: Resolve stable version
+        id: stable
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
+        with:
+          go-version: stable
+    outputs:
+      oldstable: ${{ steps.oldstable.outputs.go-version }}
+      stable: ${{ steps.stable.outputs.go-version }}
+
+  e2e-tests:
+    name: e2e-tests (${{ matrix.os }}, go ${{ matrix.go_version }})
+    needs:
+      - resolve-versions
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
+        go_version:
+          - ${{ needs.resolve-versions.outputs.oldstable }}
+          - ${{ needs.resolve-versions.outputs.stable }}
     steps:
     - name: Check out code
       uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # https://github.com/actions/checkout/releases/tag/v3.2.0
@@ -21,7 +48,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
       with:
-        go-version: '1.17'
+        go-version: ${{ matrix.go_version }}
 
     - name: E2E tests
       timeout-minutes: 35

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,45 @@ on:
       - 'CHANGELOG.md'
       - 'website/*'
 jobs:
-  build:
-    name: Build
+  # resolve-versions allows us to show resolved Go versions in job titles
+  # for added clarity and quick orientation in a long list of past jobs
+  resolve-versions:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      -
+        name: Resolve old stable version
+        id: oldstable
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
+        with:
+          go-version: oldstable
+      -
+        name: Resolve stable version
+        id: stable
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
+        with:
+          go-version: stable
+    outputs:
+      oldstable: ${{ steps.oldstable.outputs.go-version }}
+      stable: ${{ steps.stable.outputs.go-version }}
 
+  build:
+    name: build (go ${{ matrix.go_version }})
+    needs:
+      - resolve-versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        go_version:
+          - ${{ needs.resolve-versions.outputs.oldstable }}
+          - ${{ needs.resolve-versions.outputs.stable }}
+    steps:
     - name: Set up Go
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
       with:
-        go-version: '1.17'
+        go-version: ${{ matrix.go_version }}
       id: go
 
     - name: Check out code into the Go module directory
@@ -41,22 +70,26 @@ jobs:
       run: |
         go build -v .
 
-
   test:
-    name: Test
-    needs: build
+    name: tests (go ${{ matrix.go_version }})
+    needs:
+      - build
+      - resolve-versions
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
+        go_version:
+          - ${{ needs.resolve-versions.outputs.oldstable }}
+          - ${{ needs.resolve-versions.outputs.stable }}
     steps:
 
     - name: Set up Go
       uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
       with:
-        go-version: '1.17'
+        go-version: ${{ matrix.go_version }}
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
This uncovers the bug, which is being fixed as part of https://github.com/hashicorp/hc-install/pull/85

The reason tests are passing on 1.19 is because we don't install Go (as it already matches the requirement).