### PR TITLE
ci: Add OS name to test job titles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
         go build -v .
 
   test:
-    name: tests (go ${{ matrix.go_version }})
+    name: tests (${{ matrix.os }}, go ${{ matrix.go_version }})
     needs:
       - build
       - resolve-versions


### PR DESCRIPTION
This is to address the oddly ambiguous titles as shown on this screenshot.

![Screenshot 2023-01-10 at 11 33 49](https://user-images.githubusercontent.com/287584/211541489-be953e42-7fae-4df5-b7f1-bd3a0b69f3d2.png)

