### PR TITLE
internal/releasesjson: Prevent path traversal

### DIFF
--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/hashicorp/hc-install/internal/httpclient"
 )
@@ -145,6 +146,11 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 	defer r.Close()
 
 	for _, f := range r.File {
+		if strings.Contains(f.Name, "..") {
+			// While we generally trust the source ZIP file
+			// we still reject path traversal attempts as a precaution.
+			continue
+		}
 		srcFile, err := f.Open()
 		if err != nil {
 			return pkgFilePath, err


### PR DESCRIPTION
As reported by CodeQL scanner, the code in question is potentially vulnerable to path traversal, i.e. reading files outside of expected path. However, in the context of `hc-install` we generally trust the source ZIP files as hosted on `releases.hashicorp.com`, since HashiCorp produces all of them anyway.

That said, there's nothing wrong with defence in depth.

## References

 - Snyk: [Zip Slip Vulnerability](https://snyk.io/research/zip-slip-vulnerability).
 - OWASP: [Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal).
 - Common Weakness Enumeration: [CWE-22](https://cwe.mitre.org/data/definitions/22.html).