### PR TITLE
build+ci: Bump default timeouts for building

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     needs:
       - resolve-versions
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +51,7 @@ jobs:
         go-version: ${{ matrix.go_version }}
 
     - name: E2E tests
-      timeout-minutes: 35
+      timeout-minutes: 50
       env:
         E2E_TESTING: 1
       run: |

--- a/build/git_revision.go
+++ b/build/git_revision.go
@@ -18,7 +18,7 @@ import (
 var (
 	defaultPreCloneCheckTimeout = 1 * time.Minute
 	defaultCloneTimeout         = 5 * time.Minute
-	defaultBuildTimeout         = 10 * time.Minute
+	defaultBuildTimeout         = 15 * time.Minute
 
 	discardLogger = log.New(ioutil.Discard, "", 0)
 )


### PR DESCRIPTION
In the last E2E nightly test run, we exceeded the 10m timeout for building `terraform` and `consul`. This may be an anomaly on GitHub's/Azure side inside the runner, making things slower than usual.

However, the E2E tests generally aren't supposed to measure the time, but rather whether at all we can successfully build the products. Therefore there is no benefit in keeping the timeouts too low.
