### PR TITLE
fs: Set logger in Version test

### DIFF
--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -53,6 +53,7 @@ func TestVersion(t *testing.T) {
 		Version:    version.Must(version.NewVersion("1.0.0")),
 		InstallDir: p,
 	}
+	ev.SetLogger(testutil.TestLogger())
 
 	if _, err := ev.Install(ctx); err != nil {
 		t.Fatalf("installing release version failed: %v", err)


### PR DESCRIPTION
This is to help us get to the bottom of the flaky test, which sometimes fails on Windows:
https://github.com/hashicorp/hc-install/actions/runs/4074372806/jobs/7019467478#step:5:162

I wasn't able to reproduce this in a Windows VM unfortunately.