### PR TITLE
version: Trim spaces (newlines) from VERSION file

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	_ "embed"
+	"strings"
 
 	"github.com/hashicorp/go-version"
 )
@@ -16,5 +17,5 @@ var rawVersion string
 // In general downstream should not implement version-specific
 // logic and rely on this function to be present in future releases.
 func Version() *version.Version {
-	return version.Must(version.NewVersion(rawVersion))
+	return version.Must(version.NewVersion(strings.TrimSpace(rawVersion)))
 }

--- a/version/version.go
+++ b/version/version.go
@@ -10,6 +10,9 @@ import (
 //go:embed VERSION
 var rawVersion string
 
+// parsedVersion declared here ensures that invalid versions panic early, on import
+var parsedVersion = version.Must(version.NewVersion(strings.TrimSpace(rawVersion)))
+
 // Version returns the version of the library
 //
 // Note: This is only exposed as public function/package
@@ -17,5 +20,5 @@ var rawVersion string
 // In general downstream should not implement version-specific
 // logic and rely on this function to be present in future releases.
 func Version() *version.Version {
-	return version.Must(version.NewVersion(strings.TrimSpace(rawVersion)))
+	return parsedVersion
 }


### PR DESCRIPTION
Whenever a file is edited via GitHub UI, it seems impossible to avoid the trailing newline and `go-version` is (for better or worse) sensitive to that newline.

The second commit also ensures that any invalid version will cause panic earlier, on import of the `version` package, rather than on use of `Version()` function.