### PR TITLE
ci: Disable CGO for CLI Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}
           METADATA_VERSION: ${{ env.METADATA }}
+          CGO_ENABLED: 0
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}


### PR DESCRIPTION
We learnt the hard way [elsewhere](https://github.com/hashicorp/vscode-terraform/issues/1346) that `go build` builds dynamically linked (CGO) binaries by default, at least when it's being built on the same target OS/arch (in our case linux/amd64).

This ensures that we build the `hc-install` CLI still as static binary without CGO.