### PR TITLE
ci: Bump timeout for E2E tests

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -51,8 +51,8 @@ jobs:
         go-version: ${{ matrix.go_version }}
 
     - name: E2E tests
-      timeout-minutes: 50
+      timeout-minutes: 60
       env:
         E2E_TESTING: 1
       run: |
-        go test -timeout=30m -v ./...
+        go test -timeout=40m -v ./...


### PR DESCRIPTION
This is an attempt to address the recent failure:
https://github.com/hashicorp/hc-install/actions/runs/4350262336/jobs/7600801597#step:4:136