### PR TITLE
internal/releasesjson: replace deprecated openpgp dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/hc-install
 go 1.18
 
 require (
+	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-checkpoint v0.5.0
@@ -11,7 +12,6 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/mitchellh/cli v1.1.5
-	golang.org/x/crypto v0.8.0
 	golang.org/x/mod v0.10.0
 )
 
@@ -20,7 +20,6 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/acomagu/bufpipe v1.0.4 // indirect
 	github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
@@ -47,6 +46,7 @@ require (
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect

--- a/internal/releasesjson/checksum_downloader.go
+++ b/internal/releasesjson/checksum_downloader.go
@@ -15,8 +15,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/hashicorp/hc-install/internal/httpclient"
-	"golang.org/x/crypto/openpgp"
 )
 
 type ChecksumDownloader struct {
@@ -172,7 +172,7 @@ func (cd *ChecksumDownloader) verifySumsSignature(checksums, signature io.Reader
 		return err
 	}
 
-	_, err = openpgp.CheckDetachedSignature(el, checksums, signature)
+	_, err = openpgp.CheckDetachedSignature(el, checksums, signature, nil)
 	if err != nil {
 		return fmt.Errorf("unable to verify checksums signature: %w", err)
 	}


### PR DESCRIPTION
Switches away from the deprecated, unmaintained golang.org/x/crypto/openpgp module, and replaces it with the (mostly) drop-in, maintained, github.com/ProtonMail/go-crypto/openpgp.

This is part of a wider effort by the Go Security team to remove uses of golang.org/x/crypto/openpgp from the Go ecosystem.