### PR TITLE
Optimize checksum verification

### DIFF
--- a/internal/releasesjson/checksum_downloader.go
+++ b/internal/releasesjson/checksum_downloader.go
@@ -4,7 +4,6 @@
 package releasesjson
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -134,36 +133,6 @@ func fileMapFromChecksums(checksums strings.Builder) (ChecksumFileMap, error) {
 		csMap[parts[1]] = h
 	}
 	return csMap, nil
-}
-
-func compareChecksum(logger *log.Logger, r io.Reader, verifiedHashSum HashSum, filename string, expectedSize int64) error {
-	h := sha256.New()
-
-	// This may take a while depending on network connection as the io.Reader
-	// is expected to be http.Response.Body which streams the bytes
-	// on demand over the network.
-	logger.Printf("copying %q (%d bytes) to calculate checksum", filename, expectedSize)
-	bytesCopied, err := io.Copy(h, r)
-	if err != nil {
-		return err
-	}
-	logger.Printf("copied %d bytes of %q", bytesCopied, filename)
-
-	if expectedSize != 0 && bytesCopied != int64(expectedSize) {
-		return fmt.Errorf("unexpected size (downloaded: %d, expected: %d)",
-			bytesCopied, expectedSize)
-	}
-
-	calculatedSum := h.Sum(nil)
-	if !bytes.Equal(calculatedSum, verifiedHashSum) {
-		return fmt.Errorf("checksum mismatch (expected %q, calculated %q)",
-			verifiedHashSum,
-			hex.EncodeToString(calculatedSum))
-	}
-
-	logger.Printf("checksum matches: %q", hex.EncodeToString(calculatedSum))
-
-	return nil
 }
 
 func (cd *ChecksumDownloader) verifySumsSignature(checksums, signature io.Reader) error {

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -7,6 +7,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -95,8 +96,7 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	defer resp.Body.Close()
 
-	var pkgReader io.Reader
-	pkgReader = resp.Body
+	pkgReader := resp.Body
 
 	contentType := resp.Header.Get("content-type")
 	if !contentTypeIsZip(contentType) {
@@ -106,19 +106,6 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	expectedSize := resp.ContentLength
 
-	if d.VerifyChecksum {
-		d.Logger.Printf("verifying checksum of %q", pb.Filename)
-		// provide extra reader to calculate & compare checksum
-		var buf bytes.Buffer
-		r := io.TeeReader(resp.Body, &buf)
-		pkgReader = &buf
-
-		err := compareChecksum(d.Logger, r, verifiedChecksum, pb.Filename, expectedSize)
-		if err != nil {
-			return "", err
-		}
-	}
-
 	pkgFile, err := ioutil.TempFile("", pb.Filename)
 	if err != nil {
 		return "", err
@@ -127,19 +114,38 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 	pkgFilePath, err := filepath.Abs(pkgFile.Name())
 
 	d.Logger.Printf("copying %q (%d bytes) to %s", pb.Filename, expectedSize, pkgFile.Name())
-	// Unless the bytes were already downloaded above for checksum verification
-	// this may take a while depending on network connection as the io.Reader
-	// is expected to be http.Response.Body which streams the bytes
-	// on demand over the network.
-	bytesCopied, err := io.Copy(pkgFile, pkgReader)
-	if err != nil {
-		return pkgFilePath, err
+
+	var bytesCopied int64
+	if d.VerifyChecksum {
+		d.Logger.Printf("verifying checksum of %q", pb.Filename)
+		h := sha256.New()
+		r := io.TeeReader(resp.Body, pkgFile)
+
+		bytesCopied, err = io.Copy(h, r)
+		if err != nil {
+			return "", err
+		}
+
+		if !bytes.Equal(h.Sum(nil), verifiedChecksum) {
+			return pkgFilePath, fmt.Errorf(
+				"checksum mismatch (expected: %x, got: %x)",
+				verifiedChecksum, h.Sum(nil),
+			)
+		}
+	} else {
+		bytesCopied, err = io.Copy(pkgFile, pkgReader)
+		if err != nil {
+			return pkgFilePath, err
+		}
 	}
+
 	d.Logger.Printf("copied %d bytes to %s", bytesCopied, pkgFile.Name())
 
 	if expectedSize != 0 && bytesCopied != int64(expectedSize) {
-		return pkgFilePath, fmt.Errorf("unexpected size (downloaded: %d, expected: %d)",
-			bytesCopied, expectedSize)
+		return pkgFilePath, fmt.Errorf(
+			"unexpected size (downloaded: %d, expected: %d)",
+			bytesCopied, expectedSize,
+		)
 	}
 
 	r, err := zip.OpenReader(pkgFile.Name())

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -126,10 +126,11 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 			return "", err
 		}
 
-		if !bytes.Equal(h.Sum(nil), verifiedChecksum) {
+		calculatedSum := h.Sum(nil)
+		if !bytes.Equal(calculatedSum, verifiedChecksum) {
 			return pkgFilePath, fmt.Errorf(
 				"checksum mismatch (expected: %x, got: %x)",
-				verifiedChecksum, h.Sum(nil),
+				verifiedChecksum, calculatedSum,
 			)
 		}
 	} else {


### PR DESCRIPTION
Do not store the entire release in memory, and instead stream the download through the checksum and file simultaneously. This change will significantly help our test performance over at [coder/coder](https://github.com/coder/coder).