### PR TITLE
releases: Add benchmark for ExectVersion.Install()

### DIFF
--- a/internal/testutil/test_server.go
+++ b/internal/testutil/test_server.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func NewTestServer(t *testing.T, mockDir string) *httptest.Server {
+func NewTestServer(t testing.TB, mockDir string) *httptest.Server {
 	t.Helper()
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
This enables us to accurately measure the impact of https://github.com/hashicorp/hc-install/pull/132 (with vs without patch).

We could add the benchmark there, but with the PR made from a `main` branch it makes it difficult for me to contribute back to that PR directly, so I'm raising a separate PR.

```sh
go test ./releases -bench=BenchmarkExactVersion -benchmem -run=^#
```
```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/hc-install/releases
BenchmarkExactVersion-10    	      31	  37298613 ns/op	 8111621 B/op	    6950 allocs/op
PASS
ok  	github.com/hashicorp/hc-install/releases	2.250s
```