### PR TITLE
releases: support enterprise versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each comes with different trade-offs described below.
  - `releases.{LatestVersion,ExactVersion}` - Downloads, verifies & installs any known product from `releases.hashicorp.com`
    - **Pros:**
      - Fast and reliable way of obtaining any pre-built version of any product
+     - Allows installation of enterprise versions
    - **Cons:**
      - Installation may consume some bandwidth, disk space and a little time
      - Potentially less stable builds (see `checkpoint` below)
@@ -49,7 +50,7 @@ Each comes with different trade-offs described below.
      - Checkpoint typically contains only product versions considered stable
    - **Cons:**
      - Installation may consume some bandwidth, disk space and a little time
-     - Currently doesn't allow installation of old versions (see `releases` above)
+     - Currently doesn't allow installation of old versions or enterprise versions (see `releases` above)
  - `build.GitRevision` - Clones raw source code and builds the product from it
    - **Pros:**
      - Useful for catching bugs and incompatibilities as early as possible (prior to product release).

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Each comes with different trade-offs described below.
    - **Pros:**
      - Fast and reliable way of obtaining any pre-built version of any product
    - **Cons:**
-     - Installation may consume some bandwith, disk space and a little time
+     - Installation may consume some bandwidth, disk space and a little time
      - Potentially less stable builds (see `checkpoint` below)
  - `checkpoint.LatestVersion` - Downloads, verifies & installs any known product available in HashiCorp Checkpoint
    - **Pros:**
      - Checkpoint typically contains only product versions considered stable
    - **Cons:**
-     - Installation may consume some bandwith, disk space and a little time
-     - Currently doesn't allow installation of a old versions (see `releases` above)
+     - Installation may consume some bandwidth, disk space and a little time
+     - Currently doesn't allow installation of old versions (see `releases` above)
  - `build.GitRevision` - Clones raw source code and builds the product from it
    - **Pros:**
      - Useful for catching bugs and incompatibilities as early as possible (prior to product release).

--- a/checkpoint/latest_version.go
+++ b/checkpoint/latest_version.go
@@ -126,7 +126,7 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	if lv.ArmoredPublicKey != "" {
 		d.ArmoredPublicKey = lv.ArmoredPublicKey
 	}
-	zipFilePath, err := d.DownloadAndUnpack(ctx, pv, dstDir)
+	zipFilePath, err := d.DownloadAndUnpack(ctx, pv, dstDir, "")
 	if zipFilePath != "" {
 		lv.pathsToRemove = append(lv.pathsToRemove, zipFilePath)
 	}

--- a/installer_examples_test.go
+++ b/installer_examples_test.go
@@ -131,3 +131,29 @@ func ExampleInstaller_installAndBuildMultipleVersions() {
 		// run any tests
 	}
 }
+
+// Installation of a single exact enterprise version
+func ExampleInstaller_enterpriseVersion() {
+	ctx := context.Background()
+	i := install.NewInstaller()
+	defer i.Remove(ctx)
+	v1_9 := version.Must(version.NewVersion("1.9.8"))
+	licenseDir := "/some/path"
+
+	execPath, err := i.Install(ctx, []src.Installable{
+		&releases.ExactVersion{
+			Product: product.Vault,
+			Version: v1_9,
+			Enterprise: releases.EnterpriseOptions{
+				Enterprise: true,
+				LicenseDir: licenseDir, // required for enterprise versions
+			},
+		},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("Vault %s Enterprise installed to %s; license information installed to %s", v1_9, execPath, licenseDir)
+
+	// run any tests
+}

--- a/installer_examples_test.go
+++ b/installer_examples_test.go
@@ -144,9 +144,8 @@ func ExampleInstaller_enterpriseVersion() {
 		&releases.ExactVersion{
 			Product: product.Vault,
 			Version: v1_9,
-			Enterprise: releases.EnterpriseOptions{
-				Enterprise: true,
-				LicenseDir: licenseDir, // required for enterprise versions
+			Enterprise: &releases.EnterpriseOptions{ // specify that we want the enterprise version
+				LicenseDir: licenseDir, // where license files should be placed (required for enterprise versions)
 			},
 		},
 	})

--- a/installer_test.go
+++ b/installer_test.go
@@ -119,8 +119,7 @@ func TestInstaller_Install_enterprise(t *testing.T) {
 			Product:    product.Vault,
 			Version:    version.Must(version.NewVersion("1.9.8")),
 			InstallDir: tmpBinaryDir,
-			Enterprise: releases.EnterpriseOptions{
-				Enterprise: true,
+			Enterprise: &releases.EnterpriseOptions{
 				LicenseDir: tmpLicenseDir,
 			},
 		},

--- a/installer_test.go
+++ b/installer_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/go-version"
@@ -129,7 +130,11 @@ func TestInstaller_Install_enterprise(t *testing.T) {
 	}
 
 	// Ensure the binary was installed
-	if _, err = os.Stat(filepath.Join(tmpBinaryDir, "vault")); err != nil {
+	binName := "vault"
+	if runtime.GOOS == "windows" {
+		binName = "vault.exe"
+	}
+	if _, err = os.Stat(filepath.Join(tmpBinaryDir, binName)); err != nil {
 		t.Fatal(err)
 	}
 	// Ensure the enterprise license files were installed

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -167,11 +167,9 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 		}
 
 		// Determine the appropriate destination file path
-		var dstDir string
+		dstDir := binDir
 		if isLicenseFile(f.Name) && licenseDir != "" {
 			dstDir = licenseDir
-		} else {
-			dstDir = binDir
 		}
 
 		d.Logger.Printf("unpacking %s to %s", f.Name, dstDir)

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -29,7 +29,7 @@ type Downloader struct {
 	BaseURL          string
 }
 
-func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, dstDir string) (zipFilePath string, err error) {
+func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, binDir string, licenseDir string) (zipFilePath string, err error) {
 	if len(pv.Builds) == 0 {
 		return "", fmt.Errorf("no builds found for %s %s", pv.Name, pv.Version)
 	}
@@ -166,6 +166,14 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 			return pkgFilePath, err
 		}
 
+		// Determine the appropriate destination file path
+		var dstDir string
+		if isLicenseFile(f.Name) && licenseDir != "" {
+			dstDir = licenseDir
+		} else {
+			dstDir = binDir
+		}
+
 		d.Logger.Printf("unpacking %s to %s", f.Name, dstDir)
 		dstPath := filepath.Join(dstDir, f.Name)
 		dstFile, err := os.Create(dstPath)
@@ -195,6 +203,22 @@ var zipMimeTypes = []string{
 func contentTypeIsZip(contentType string) bool {
 	for _, mt := range zipMimeTypes {
 		if mt == contentType {
+			return true
+		}
+	}
+	return false
+}
+
+// Enterprise products have a few additional license files
+// that need to be extracted to a separate directory
+var licenseFiles = []string{
+	"EULA.txt",
+	"TermsOfEvaluation.txt",
+}
+
+func isLicenseFile(filename string) bool {
+	for _, lf := range licenseFiles {
+		if lf == filename {
 			return true
 		}
 	}

--- a/internal/releasesjson/releases.go
+++ b/internal/releasesjson/releases.go
@@ -115,13 +115,6 @@ func (r *Releases) ListProductVersions(ctx context.Context, productName string) 
 			continue
 		}
 
-		if ok, _ := versionIsSupported(v); !ok {
-			// Remove (currently unsupported) enterprise
-			// version and any other "custom" build
-			delete(p.Versions, rawVersion)
-			continue
-		}
-
 		p.Versions[rawVersion].Version = v
 	}
 
@@ -129,10 +122,6 @@ func (r *Releases) ListProductVersions(ctx context.Context, productName string) 
 }
 
 func (r *Releases) GetProductVersion(ctx context.Context, product string, version *version.Version) (*ProductVersion, error) {
-	if ok, err := versionIsSupported(version); !ok {
-		return nil, fmt.Errorf("%s: %w", product, err)
-	}
-
 	client := httpclient.NewHTTPClient()
 
 	indexURL := fmt.Sprintf("%s/%s/%s/index.json",
@@ -177,13 +166,4 @@ func (r *Releases) GetProductVersion(ctx context.Context, product string, versio
 	}
 
 	return pv, nil
-}
-
-func versionIsSupported(v *version.Version) (bool, error) {
-	isSupported := v.Metadata() == ""
-	if !isSupported {
-		return false, fmt.Errorf("cannot obtain %s (enterprise versions are not supported)",
-			v.String())
-	}
-	return true, nil
 }

--- a/internal/releasesjson/releases_test.go
+++ b/internal/releasesjson/releases_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/hc-install/internal/testutil"
 )
 
-func TestListProductVersions_excludesEnterpriseBuilds(t *testing.T) {
+func TestListProductVersions_includesEnterpriseBuilds(t *testing.T) {
 	testutil.EndToEndTest(t)
 
 	r := NewReleases()
@@ -25,12 +25,12 @@ func TestListProductVersions_excludesEnterpriseBuilds(t *testing.T) {
 
 	testEntVersion := "1.9.8+ent"
 	_, ok := pVersions[testEntVersion]
-	if ok {
-		t.Fatalf("Found unexpected Consul Enterprise version %q", testEntVersion)
+	if !ok {
+		t.Fatalf("Failed to find expected Consul Enterprise version %q", testEntVersion)
 	}
 }
 
-func TestGetProductVersion_excludesEnterpriseBuild(t *testing.T) {
+func TestGetProductVersion_includesEnterpriseBuild(t *testing.T) {
 	testutil.EndToEndTest(t)
 
 	r := NewReleases()
@@ -40,9 +40,13 @@ func TestGetProductVersion_excludesEnterpriseBuild(t *testing.T) {
 
 	testEntVersion := version.Must(version.NewVersion("1.9.8+ent"))
 
-	_, err := r.GetProductVersion(ctx, "consul", testEntVersion)
-	if err == nil {
-		t.Fatalf("Expected enterprise version %q to error out",
+	version, err := r.GetProductVersion(ctx, "consul", testEntVersion)
+	if err != nil {
+		t.Fatalf("Unexpected error getting enterprise version %q",
 			testEntVersion.String())
+	}
+
+	if version.RawVersion != testEntVersion.Original() {
+		t.Fatalf("Expected version %q, got %q", testEntVersion.String(), version.Version.String())
 	}
 }

--- a/releases/enterprise.go
+++ b/releases/enterprise.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package releases
 
 import (

--- a/releases/enterprise.go
+++ b/releases/enterprise.go
@@ -22,7 +22,7 @@ func (eo *EnterpriseOptions) requiredMetadata() string {
 
 func (eo *EnterpriseOptions) validate() error {
 	if eo.LicenseDir == "" {
-		return fmt.Errorf("license dir must be provided when requesting enterprise versions")
+		return fmt.Errorf("LicenseDir must be provided when requesting enterprise versions")
 	}
 	return nil
 }

--- a/releases/enterprise.go
+++ b/releases/enterprise.go
@@ -8,16 +8,12 @@ import (
 )
 
 type EnterpriseOptions struct {
-	Enterprise bool
+	LicenseDir string // required
 	Meta       string // optional; may be "hsm", "fips1402", "hsm.fips1402", etc.
-	LicenseDir string // required when Enterprise is true
 }
 
 func (eo *EnterpriseOptions) requiredMetadata() string {
-	metadata := ""
-	if eo.Enterprise {
-		metadata += "ent"
-	}
+	metadata := "ent"
 	if eo.Meta != "" {
 		metadata += "." + eo.Meta
 	}
@@ -25,7 +21,7 @@ func (eo *EnterpriseOptions) requiredMetadata() string {
 }
 
 func (eo *EnterpriseOptions) validate() error {
-	if eo.Enterprise && eo.LicenseDir == "" {
+	if eo.LicenseDir == "" {
 		return fmt.Errorf("license dir must be provided when requesting enterprise versions")
 	}
 	return nil

--- a/releases/enterprise.go
+++ b/releases/enterprise.go
@@ -3,16 +3,21 @@
 
 package releases
 
-import (
-	"fmt"
-)
+import "fmt"
 
 type EnterpriseOptions struct {
-	LicenseDir string // required
-	Meta       string // optional; may be "hsm", "fips1402", "hsm.fips1402", etc.
+	// LicenseDir represents directory path where to install license files (required)
+	LicenseDir string
+
+	// Meta represents optional version metadata (e.g. hsm, fips1402)
+	Meta string
 }
 
-func (eo *EnterpriseOptions) requiredMetadata() string {
+func enterpriseVersionMetadata(eo *EnterpriseOptions) string {
+	if eo == nil {
+		return ""
+	}
+
 	metadata := "ent"
 	if eo.Meta != "" {
 		metadata += "." + eo.Meta
@@ -20,9 +25,14 @@ func (eo *EnterpriseOptions) requiredMetadata() string {
 	return metadata
 }
 
-func (eo *EnterpriseOptions) validate() error {
+func validateEnterpriseOptions(eo *EnterpriseOptions) error {
+	if eo == nil {
+		return nil
+	}
+
 	if eo.LicenseDir == "" {
 		return fmt.Errorf("LicenseDir must be provided when requesting enterprise versions")
 	}
+
 	return nil
 }

--- a/releases/enterprise.go
+++ b/releases/enterprise.go
@@ -1,8 +1,13 @@
 package releases
 
+import (
+	"fmt"
+)
+
 type EnterpriseOptions struct {
 	Enterprise bool
 	Meta       string // optional; may be "hsm", "fips1402", "hsm.fips1402", etc.
+	LicenseDir string // required when Enterprise is true
 }
 
 func (eo *EnterpriseOptions) requiredMetadata() string {
@@ -14,4 +19,11 @@ func (eo *EnterpriseOptions) requiredMetadata() string {
 		metadata += "." + eo.Meta
 	}
 	return metadata
+}
+
+func (eo *EnterpriseOptions) validate() error {
+	if eo.Enterprise && eo.LicenseDir == "" {
+		return fmt.Errorf("license dir must be provided when requesting enterprise versions")
+	}
+	return nil
 }

--- a/releases/enterprise.go
+++ b/releases/enterprise.go
@@ -1,0 +1,17 @@
+package releases
+
+type EnterpriseOptions struct {
+	Enterprise bool
+	Meta       string // optional; may be "hsm", "fips1402", "hsm.fips1402", etc.
+}
+
+func (eo *EnterpriseOptions) requiredMetadata() string {
+	metadata := ""
+	if eo.Enterprise {
+		metadata += "ent"
+	}
+	if eo.Meta != "" {
+		metadata += "." + eo.Meta
+	}
+	return metadata
+}

--- a/releases/exact_version.go
+++ b/releases/exact_version.go
@@ -27,6 +27,7 @@ type ExactVersion struct {
 	Version    *version.Version
 	InstallDir string
 	Timeout    time.Duration
+	Enterprise EnterpriseOptions
 
 	SkipChecksumVerification bool
 
@@ -100,7 +101,7 @@ func (ev *ExactVersion) Install(ctx context.Context) (string, error) {
 		rels.BaseURL = ev.apiBaseURL
 	}
 	rels.SetLogger(ev.log())
-	pv, err := rels.GetProductVersion(ctx, ev.Product.Name, ev.Version)
+	pv, err := rels.GetProductVersion(ctx, ev.Product.Name, versionWithMetadata(ev.Version, ev.Enterprise.requiredMetadata()))
 	if err != nil {
 		return "", err
 	}
@@ -150,4 +151,22 @@ func (ev *ExactVersion) Remove(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// versionWithMetadata returns a new version by combining the given version with the given metadata
+func versionWithMetadata(v *version.Version, metadata string) *version.Version {
+	if v == nil {
+		return nil
+	}
+
+	if metadata == "" {
+		return v
+	}
+
+	v2, err := version.NewVersion(fmt.Sprintf("%s+%s", v.Core(), metadata))
+	if err != nil {
+		return nil
+	}
+
+	return v2
 }

--- a/releases/exact_version.go
+++ b/releases/exact_version.go
@@ -68,6 +68,10 @@ func (ev *ExactVersion) Validate() error {
 		return fmt.Errorf("unknown version")
 	}
 
+	if err := ev.Enterprise.validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -119,7 +123,7 @@ func (ev *ExactVersion) Install(ctx context.Context) (string, error) {
 		d.BaseURL = ev.apiBaseURL
 	}
 
-	zipFilePath, err := d.DownloadAndUnpack(ctx, pv, dstDir)
+	zipFilePath, err := d.DownloadAndUnpack(ctx, pv, dstDir, ev.Enterprise.LicenseDir)
 	if zipFilePath != "" {
 		ev.pathsToRemove = append(ev.pathsToRemove, zipFilePath)
 	}

--- a/releases/exact_version_test.go
+++ b/releases/exact_version_test.go
@@ -54,7 +54,7 @@ func TestExactVersionValidate(t *testing.T) {
 				Version:    version.Must(version.NewVersion("1.9.8")),
 				Enterprise: &EnterpriseOptions{},
 			},
-			expectedErr: fmt.Errorf("license dir must be provided when requesting enterprise versions"),
+			expectedErr: fmt.Errorf("LicenseDir must be provided when requesting enterprise versions"),
 		},
 	}
 

--- a/releases/exact_version_test.go
+++ b/releases/exact_version_test.go
@@ -48,6 +48,16 @@ func TestExactVersionValidate(t *testing.T) {
 			},
 			expectedErr: fmt.Errorf("unknown version"),
 		},
+		"Enterprise-missing-license-dir": {
+			ev: ExactVersion{
+				Product: product.Vault,
+				Version: version.Must(version.NewVersion("1.9.8")),
+				Enterprise: EnterpriseOptions{
+					Enterprise: true,
+				},
+			},
+			expectedErr: fmt.Errorf("license dir must be provided when requesting enterprise versions"),
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/releases/exact_version_test.go
+++ b/releases/exact_version_test.go
@@ -50,11 +50,9 @@ func TestExactVersionValidate(t *testing.T) {
 		},
 		"Enterprise-missing-license-dir": {
 			ev: ExactVersion{
-				Product: product.Vault,
-				Version: version.Must(version.NewVersion("1.9.8")),
-				Enterprise: EnterpriseOptions{
-					Enterprise: true,
-				},
+				Product:    product.Vault,
+				Version:    version.Must(version.NewVersion("1.9.8")),
+				Enterprise: &EnterpriseOptions{},
 			},
 			expectedErr: fmt.Errorf("license dir must be provided when requesting enterprise versions"),
 		},

--- a/releases/latest_version.go
+++ b/releases/latest_version.go
@@ -64,6 +64,10 @@ func (lv *LatestVersion) Validate() error {
 		return fmt.Errorf("invalid binary name: %q", lv.Product.BinaryName())
 	}
 
+	if err := lv.Enterprise.validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -123,7 +127,7 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	if lv.apiBaseURL != "" {
 		d.BaseURL = lv.apiBaseURL
 	}
-	zipFilePath, err := d.DownloadAndUnpack(ctx, versionToInstall, dstDir)
+	zipFilePath, err := d.DownloadAndUnpack(ctx, versionToInstall, dstDir, lv.Enterprise.LicenseDir)
 	if zipFilePath != "" {
 		lv.pathsToRemove = append(lv.pathsToRemove, zipFilePath)
 	}

--- a/releases/latest_version.go
+++ b/releases/latest_version.go
@@ -27,8 +27,7 @@ type LatestVersion struct {
 	InstallDir         string
 	Timeout            time.Duration
 	IncludePrereleases bool
-	Enterprise         bool   // Require "+ent" suffix?
-	EnterpriseMeta     string // "hsm", "fips1402", "hsm.fips1402", etc.
+	Enterprise         EnterpriseOptions
 
 	SkipChecksumVerification bool
 
@@ -158,7 +157,7 @@ func (lv *LatestVersion) Remove(ctx context.Context) error {
 }
 
 func (lv *LatestVersion) findLatestMatchingVersion(pvs rjson.ProductVersionsMap, vc version.Constraints) (*rjson.ProductVersion, bool) {
-	requiredMetadata := lv.requiredMetadata()
+	requiredMetadata := lv.Enterprise.requiredMetadata()
 	versions := make(version.Collection, 0)
 	for _, pv := range pvs.AsSlice() {
 		if !lv.IncludePrereleases && pv.Version.Prerelease() != "" {
@@ -181,15 +180,4 @@ func (lv *LatestVersion) findLatestMatchingVersion(pvs rjson.ProductVersionsMap,
 	latestVersion := versions[len(versions)-1]
 
 	return pvs[latestVersion.Original()], true
-}
-
-func (lv *LatestVersion) requiredMetadata() string {
-	metadata := ""
-	if lv.Enterprise {
-		metadata += "ent"
-	}
-	if lv.EnterpriseMeta != "" {
-		metadata += "." + lv.EnterpriseMeta
-	}
-	return metadata
 }

--- a/releases/latest_version_test.go
+++ b/releases/latest_version_test.go
@@ -47,7 +47,7 @@ func TestLatestVersionValidate(t *testing.T) {
 				Product:    product.Vault,
 				Enterprise: &EnterpriseOptions{},
 			},
-			expectedErr: fmt.Errorf("license dir must be provided when requesting enterprise versions"),
+			expectedErr: fmt.Errorf("LicenseDir must be provided when requesting enterprise versions"),
 		},
 	}
 

--- a/releases/latest_version_test.go
+++ b/releases/latest_version_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-version"
+	rjson "github.com/hashicorp/hc-install/internal/releasesjson"
 	"github.com/hashicorp/hc-install/product"
 )
 
@@ -60,6 +62,66 @@ func TestLatestVersionValidate(t *testing.T) {
 
 			if err != nil && testCase.expectedErr != nil && err.Error() != testCase.expectedErr.Error() {
 				t.Fatalf("expected error: %s, got error: %s", testCase.expectedErr, err)
+			}
+		})
+	}
+}
+
+func TestLatestVersion_FindLatestMatchingVersion(t *testing.T) {
+	t.Parallel()
+
+	possibleVersions := rjson.ProductVersionsMap{
+		"1.14.0": &rjson.ProductVersion{
+			Version: version.Must(version.NewVersion("1.14.0")),
+		},
+		"1.14.1": &rjson.ProductVersion{
+			Version: version.Must(version.NewVersion("1.14.1")),
+		},
+		"1.14.1+ent": &rjson.ProductVersion{
+			Version: version.Must(version.NewVersion("1.14.1+ent")),
+		},
+		"1.14.1+ent.fips1402": &rjson.ProductVersion{
+			Version: version.Must(version.NewVersion("1.14.1+ent.fips1402")),
+		},
+	}
+
+	testCases := map[string]struct {
+		lv              LatestVersion
+		expectedVersion string
+	}{
+		"oss": {
+			lv: LatestVersion{
+				Product: product.Vault,
+			},
+			expectedVersion: "1.14.1",
+		},
+		"enterprise": {
+			lv: LatestVersion{
+				Product:    product.Vault,
+				Enterprise: true,
+			},
+			expectedVersion: "1.14.1+ent",
+		},
+		"enterprise-fips1402": {
+			lv: LatestVersion{
+				Product:        product.Vault,
+				Enterprise:     true,
+				EnterpriseMeta: "fips1402",
+			},
+			expectedVersion: "1.14.1+ent.fips1402",
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			latest, _ := testCase.lv.findLatestMatchingVersion(possibleVersions, testCase.lv.Constraints)
+
+			if latest.Version.Original() != testCase.expectedVersion {
+				t.Fatalf("expected version %s, got %s", testCase.expectedVersion, latest.Version.Original())
 			}
 		})
 	}

--- a/releases/latest_version_test.go
+++ b/releases/latest_version_test.go
@@ -44,10 +44,8 @@ func TestLatestVersionValidate(t *testing.T) {
 		},
 		"Enterprise-missing-license-dir": {
 			lv: LatestVersion{
-				Product: product.Vault,
-				Enterprise: EnterpriseOptions{
-					Enterprise: true,
-				},
+				Product:    product.Vault,
+				Enterprise: &EnterpriseOptions{},
 			},
 			expectedErr: fmt.Errorf("license dir must be provided when requesting enterprise versions"),
 		},
@@ -106,19 +104,16 @@ func TestLatestVersion_FindLatestMatchingVersion(t *testing.T) {
 		},
 		"enterprise": {
 			lv: LatestVersion{
-				Product: product.Vault,
-				Enterprise: EnterpriseOptions{
-					Enterprise: true,
-				},
+				Product:    product.Vault,
+				Enterprise: &EnterpriseOptions{},
 			},
 			expectedVersion: "1.14.1+ent",
 		},
 		"enterprise-fips1402": {
 			lv: LatestVersion{
 				Product: product.Vault,
-				Enterprise: EnterpriseOptions{
-					Enterprise: true,
-					Meta:       "fips1402",
+				Enterprise: &EnterpriseOptions{
+					Meta: "fips1402",
 				},
 			},
 			expectedVersion: "1.14.1+ent.fips1402",

--- a/releases/latest_version_test.go
+++ b/releases/latest_version_test.go
@@ -42,6 +42,15 @@ func TestLatestVersionValidate(t *testing.T) {
 				Product: product.Terraform,
 			},
 		},
+		"Enterprise-missing-license-dir": {
+			lv: LatestVersion{
+				Product: product.Vault,
+				Enterprise: EnterpriseOptions{
+					Enterprise: true,
+				},
+			},
+			expectedErr: fmt.Errorf("license dir must be provided when requesting enterprise versions"),
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/releases/latest_version_test.go
+++ b/releases/latest_version_test.go
@@ -97,16 +97,20 @@ func TestLatestVersion_FindLatestMatchingVersion(t *testing.T) {
 		},
 		"enterprise": {
 			lv: LatestVersion{
-				Product:    product.Vault,
-				Enterprise: true,
+				Product: product.Vault,
+				Enterprise: EnterpriseOptions{
+					Enterprise: true,
+				},
 			},
 			expectedVersion: "1.14.1+ent",
 		},
 		"enterprise-fips1402": {
 			lv: LatestVersion{
-				Product:        product.Vault,
-				Enterprise:     true,
-				EnterpriseMeta: "fips1402",
+				Product: product.Vault,
+				Enterprise: EnterpriseOptions{
+					Enterprise: true,
+					Meta:       "fips1402",
+				},
 			},
 			expectedVersion: "1.14.1+ent.fips1402",
 		},

--- a/releases/versions.go
+++ b/releases/versions.go
@@ -46,6 +46,10 @@ func (v *Versions) List(ctx context.Context) ([]src.Source, error) {
 		return nil, fmt.Errorf("invalid product name: %q", v.Product.Name)
 	}
 
+	if err := v.Enterprise.validate(); err != nil {
+		return nil, err
+	}
+
 	timeout := defaultListTimeout
 	if v.ListTimeout > 0 {
 		timeout = v.ListTimeout

--- a/releases/versions.go
+++ b/releases/versions.go
@@ -83,12 +83,18 @@ func (v *Versions) List(ctx context.Context) ([]src.Source, error) {
 		ev := &ExactVersion{
 			Product:    v.Product,
 			Version:    pv.Version,
-			Enterprise: v.Enterprise,
 			InstallDir: v.Install.Dir,
 			Timeout:    v.Install.Timeout,
 
 			ArmoredPublicKey:         v.Install.ArmoredPublicKey,
 			SkipChecksumVerification: v.Install.SkipChecksumVerification,
+		}
+
+		if v.Enterprise != nil {
+			ev.Enterprise = &EnterpriseOptions{
+				Meta:       v.Enterprise.Meta,
+				LicenseDir: v.Enterprise.LicenseDir,
+			}
 		}
 
 		installables = append(installables, ev)

--- a/releases/versions_test.go
+++ b/releases/versions_test.go
@@ -61,8 +61,7 @@ func TestVersions_List_enterprise(t *testing.T) {
 	versions := &Versions{
 		Product:     product.Vault,
 		Constraints: cons,
-		Enterprise: EnterpriseOptions{
-			Enterprise: true,
+		Enterprise: &EnterpriseOptions{
 			Meta:       "hsm",
 			LicenseDir: "/some/path",
 		},
@@ -90,11 +89,11 @@ func TestVersions_List_enterprise(t *testing.T) {
 	}
 
 	for _, source := range sources {
-		if source.(*ExactVersion).Enterprise != versions.Enterprise {
+		if *source.(*ExactVersion).Enterprise != *versions.Enterprise {
 			t.Fatalf("unexpected Enterprise data: %v", source.(*ExactVersion).Enterprise)
 		}
 
-		if &source.(*ExactVersion).Enterprise == &versions.Enterprise {
+		if source.(*ExactVersion).Enterprise == versions.Enterprise {
 			t.Fatalf("the Enterprise data should be copied, not referenced")
 		}
 	}

--- a/releases/versions_test.go
+++ b/releases/versions_test.go
@@ -64,6 +64,7 @@ func TestVersions_List_enterprise(t *testing.T) {
 		Enterprise: EnterpriseOptions{
 			Enterprise: true,
 			Meta:       "hsm",
+			LicenseDir: "/some/path",
 		},
 	}
 

--- a/releases/versions_test.go
+++ b/releases/versions_test.go
@@ -50,6 +50,55 @@ func TestVersions_List(t *testing.T) {
 	}
 }
 
+func TestVersions_List_enterprise(t *testing.T) {
+	testutil.EndToEndTest(t)
+
+	cons, err := version.NewConstraint(">= 1.9.0, < 1.9.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	versions := &Versions{
+		Product:     product.Vault,
+		Constraints: cons,
+		Enterprise: EnterpriseOptions{
+			Enterprise: true,
+			Meta:       "hsm",
+		},
+	}
+
+	ctx := context.Background()
+	sources, err := versions.List(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedVersions := []string{
+		"1.9.0+ent.hsm",
+		"1.9.1+ent.hsm",
+		"1.9.2+ent.hsm",
+		"1.9.3+ent.hsm",
+		"1.9.4+ent.hsm",
+		"1.9.5+ent.hsm",
+		"1.9.6+ent.hsm",
+		"1.9.7+ent.hsm",
+		"1.9.8+ent.hsm",
+	}
+	if diff := cmp.Diff(expectedVersions, sourcesToRawVersions(sources)); diff != "" {
+		t.Fatalf("unexpected versions: %s", diff)
+	}
+
+	for _, source := range sources {
+		if source.(*ExactVersion).Enterprise != versions.Enterprise {
+			t.Fatalf("unexpected Enterprise data: %v", source.(*ExactVersion).Enterprise)
+		}
+
+		if &source.(*ExactVersion).Enterprise == &versions.Enterprise {
+			t.Fatalf("the Enterprise data should be copied, not referenced")
+		}
+	}
+}
+
 func sourcesToRawVersions(srcs []src.Source) []string {
 	rawVersions := make([]string, len(srcs))
 


### PR DESCRIPTION
This pull request allows the installation of enterprise versions by supplying an `Enterprise bool` flag and an optional `EnterpriseMeta string` field as suggested in https://github.com/hashicorp/hc-install/issues/15#issuecomment-881566106.

---

According to #15 and #16, the ability to download enterprise versions was removed from the public release of this library. It seems this decision was likely made to prevent users from accidentally installing Enterprise versions.  However, there are some valid cases folks have the need to automate the downloading of Enterprise versions:

 - [Automated testing of the Consul API Gateway project against the latest Consul Enterprise binaries](https://github.com/hashicorp/hc-install/issues/15#issuecomment-962244883)
 - Preinstalling the latest enterprise versions of binaries on users' laptops (my use case)

With these proposed changes, users of this library can now opt-in to fetching the Enterprise versions as needed, without negatively impacting the ability for OSS users to continue using the OSS releases.