### PR TITLE
build: Adapt to new Go toolchain versioning change in 1.21

### DIFF
--- a/internal/build/install_go_version.go
+++ b/internal/build/install_go_version.go
@@ -13,14 +13,21 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+var v1_21 = version.Must(version.NewVersion("1.21"))
+
 // installGoVersion installs given version of Go using Go
 // according to https://golang.org/doc/manage-install
 func (gb *GoBuild) installGoVersion(ctx context.Context, v *version.Version) (Go, error) {
-	versionString := v.Core().String()
+	goVersion := v.String()
 
-	// trim 0 patch versions as that's how Go does it :shrug:
-	shortVersion := strings.TrimSuffix(versionString, ".0")
-	pkgURL := fmt.Sprintf("golang.org/dl/go%s", shortVersion)
+	// trim 0 patch versions as that's how Go does it
+	// for versions prior to 1.21
+	// See https://github.com/golang/go/issues/62136
+	if v.LessThan(v1_21) {
+		versionString := v.Core().String()
+		goVersion = strings.TrimSuffix(versionString, ".0")
+	}
+	pkgURL := fmt.Sprintf("golang.org/dl/go%s", goVersion)
 
 	gb.log().Printf("go getting %q", pkgURL)
 	cmd := exec.CommandContext(ctx, "go", "get", pkgURL)
@@ -36,7 +43,7 @@ func (gb *GoBuild) installGoVersion(ctx context.Context, v *version.Version) (Go
 		return Go{}, fmt.Errorf("unable to install Go %s: %w\n%s", v, err, out)
 	}
 
-	cmdName := fmt.Sprintf("go%s", shortVersion)
+	cmdName := fmt.Sprintf("go%s", goVersion)
 
 	gb.log().Printf("downloading go %q", v)
 	cmd = exec.CommandContext(ctx, cmdName, "download")


### PR DESCRIPTION
Currently one test in `build` is failing because of a minor change in how Go toolchain versions are identified:

```
E2E_TESTING=1 go test ./build -run=TestGitRevision_vault -v
=== RUN   TestGitRevision_vault
2023/08/23 09:29:40 git_revision.go:91: running vault pre-clone check (timeout: 1m0s)
2023/08/23 09:29:40 git_revision.go:97: vault pre-clone check finished
2023/08/23 09:29:40 git_revision.go:126: cloning vault repository from https://github.com/hashicorp/vault.git to /var/folders/9w/pddq2x656j76vxvsbhcs4nwr0000gq/T/hc-install-build-vault2469906280 (timeout: 5m0s)
2023/08/23 09:33:07 git_revision.go:139: cloning vault finished
2023/08/23 09:33:07 git_revision.go:145: vault repository HEAD is at e4ce8729fde726ed933d231a2eb5e252af229bc1
2023/08/23 09:33:07 git_revision.go:172: building vault (timeout: 15m0s)
2023/08/23 09:33:07 go_build.go:132: attempting to satisfy guessed Go requirement 1.21.0
2023/08/23 09:33:07 install_go_version.go:25: go getting "golang.org/dl/go1.21"
2023/08/23 09:33:09 git_revision.go:174: building of vault finished
    git_revision_test.go:91: unable to get Go 1.21.0: exit status 1
        go: downloading golang.org/dl v0.0.0-20230818220345-55c644201171
        go: module golang.org/dl@upgrade found (v0.0.0-20230818220345-55c644201171), but does not contain package golang.org/dl/go1.21

--- FAIL: TestGitRevision_vault (209.45s)
FAIL
FAIL	github.com/hashicorp/hc-install/build	209.612s
FAIL
```

See https://github.com/golang/go/issues/62136