### PR TITLE
build: bump `BuildTimeout` from `15` to `25 mins`

### DIFF
--- a/build/git_revision.go
+++ b/build/git_revision.go
@@ -21,7 +21,7 @@ import (
 var (
 	defaultPreCloneCheckTimeout = 1 * time.Minute
 	defaultCloneTimeout         = 5 * time.Minute
-	defaultBuildTimeout         = 15 * time.Minute
+	defaultBuildTimeout         = 25 * time.Minute
 
 	discardLogger = log.New(ioutil.Discard, "", 0)
 )


### PR DESCRIPTION
This is to address recent test failures where it seems impossible to build vault within the existing 15 min limit.

https://github.com/hashicorp/hc-install/actions/runs/5952076475/job/16143254859#step:5:82
