### PR TITLE
`LatestVersion` - use version `Constraints` passed in

### DIFF
--- a/releases/latest_version.go
+++ b/releases/latest_version.go
@@ -179,7 +179,9 @@ func (lv *LatestVersion) findLatestMatchingVersion(pvs rjson.ProductVersionsMap,
 			continue
 		}
 
-		versions = append(versions, pv.Version)
+		if vc.Check(pv.Version) {
+			versions = append(versions, pv.Version)
+		}
 	}
 
 	if len(versions) == 0 {

--- a/releases/latest_version_test.go
+++ b/releases/latest_version_test.go
@@ -84,6 +84,9 @@ func TestLatestVersion_FindLatestMatchingVersion(t *testing.T) {
 		"1.14.1": &rjson.ProductVersion{
 			Version: version.Must(version.NewVersion("1.14.1")),
 		},
+		"1.15.2": &rjson.ProductVersion{
+			Version: version.Must(version.NewVersion("1.15.2")),
+		},
 		"1.14.1+ent": &rjson.ProductVersion{
 			Version: version.Must(version.NewVersion("1.14.1+ent")),
 		},
@@ -91,14 +94,22 @@ func TestLatestVersion_FindLatestMatchingVersion(t *testing.T) {
 			Version: version.Must(version.NewVersion("1.14.1+ent.fips1402")),
 		},
 	}
+	constraints, _ := version.NewConstraint("~> 1.14.0")
 
 	testCases := map[string]struct {
 		lv              LatestVersion
 		expectedVersion string
 	}{
-		"oss": {
+		"oss1": {
 			lv: LatestVersion{
 				Product: product.Vault,
+			},
+			expectedVersion: "1.15.2",
+		},
+		"oss2": {
+			lv: LatestVersion{
+				Product:     product.Vault,
+				Constraints: constraints,
 			},
 			expectedVersion: "1.14.1",
 		},

--- a/releases/latest_version_test.go
+++ b/releases/latest_version_test.go
@@ -94,7 +94,6 @@ func TestLatestVersion_FindLatestMatchingVersion(t *testing.T) {
 			Version: version.Must(version.NewVersion("1.14.1+ent.fips1402")),
 		},
 	}
-	constraints, _ := version.NewConstraint("~> 1.14.0")
 
 	testCases := map[string]struct {
 		lv              LatestVersion
@@ -109,7 +108,7 @@ func TestLatestVersion_FindLatestMatchingVersion(t *testing.T) {
 		"oss2": {
 			lv: LatestVersion{
 				Product:     product.Vault,
-				Constraints: constraints,
+				Constraints: version.MustConstraints(version.NewConstraint("~> 1.14.0")),
 			},
 			expectedVersion: "1.14.1",
 		},


### PR DESCRIPTION
This uses the version constraint passed into the `LatestVersion` struct to ensure the constraints are checked against the returned versions.