### PR TITLE
github/release: Ensure production workflow doesn't start before staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
 
   production:
     runs-on: ubuntu-latest
+    needs: staging
     steps:
       - name: Setup bob
         uses: hashicorp/action-setup-bob@v1


### PR DESCRIPTION
The `production` promotion is gated by human approval and AFAICT does not require `staging` to actually _finish_ the promotion before it gets to the approval point.

However, it still doesn't make much sense to even attempt to promote artifacts in staging to production before the promotion to staging has actually finished.

Admittedly this change won't actually fully achieve that, because as the command name suggests, it only _triggers_ the promotion (i.e. won't wait for completion of the promotion). We can at least avoid _triggering_ production promotion if the triggering the staging promotion fails though.