### PR TITLE
releasesjson: Fix missing Version in unmarshaled response

### DIFF
--- a/internal/releasesjson/checksum_downloader.go
+++ b/internal/releasesjson/checksum_downloader.go
@@ -55,7 +55,7 @@ func (cd *ChecksumDownloader) DownloadAndVerifyChecksums(ctx context.Context) (C
 	client := httpclient.NewHTTPClient()
 	sigURL := fmt.Sprintf("%s/%s/%s/%s", cd.BaseURL,
 		url.PathEscape(cd.ProductVersion.Name),
-		url.PathEscape(cd.ProductVersion.RawVersion),
+		url.PathEscape(cd.ProductVersion.Version.String()),
 		url.PathEscape(sigFilename))
 	cd.Logger.Printf("downloading signature from %s", sigURL)
 
@@ -76,7 +76,7 @@ func (cd *ChecksumDownloader) DownloadAndVerifyChecksums(ctx context.Context) (C
 
 	shasumsURL := fmt.Sprintf("%s/%s/%s/%s", cd.BaseURL,
 		url.PathEscape(cd.ProductVersion.Name),
-		url.PathEscape(cd.ProductVersion.RawVersion),
+		url.PathEscape(cd.ProductVersion.Version.String()),
 		url.PathEscape(cd.ProductVersion.SHASUMS))
 	cd.Logger.Printf("downloading checksums from %s", shasumsURL)
 

--- a/internal/releasesjson/product_version.go
+++ b/internal/releasesjson/product_version.go
@@ -9,8 +9,7 @@ import "github.com/hashicorp/go-version"
 // "consul 0.5.1". A ProductVersion may have one or more builds.
 type ProductVersion struct {
 	Name        string           `json:"name"`
-	RawVersion  string           `json:"version"`
-	Version     *version.Version `json:"-"`
+	Version     *version.Version `json:"version"`
 	SHASUMS     string           `json:"shasums,omitempty"`
 	SHASUMSSig  string           `json:"shasums_signature,omitempty"`
 	SHASUMSSigs []string         `json:"shasums_signatures,omitempty"`

--- a/internal/releasesjson/releases_test.go
+++ b/internal/releasesjson/releases_test.go
@@ -46,7 +46,7 @@ func TestGetProductVersion_includesEnterpriseBuild(t *testing.T) {
 			testEntVersion.String())
 	}
 
-	if version.RawVersion != testEntVersion.Original() {
+	if version.Version.String() != testEntVersion.Original() {
 		t.Fatalf("Expected version %q, got %q", testEntVersion.String(), version.Version.String())
 	}
 }


### PR DESCRIPTION
I cannot think of a good reason why we had the `RawVersion` field there. It may have pre-dated `go-version`'s ability to unmarshal. Either way, this has led to a weird error message, as discovered by @bschaatsbergen in #191 

```
 $ ./hc-install install -version 1.0.0 terraform
hc-install: will install terraform@1.0.0
failed to install terraform@1.0.0: no ZIP archive found for terraform <nil> darwin/arm64
```

### After patch

```
$ go run ./cmd/hc-install install -version 1.0.0 terraform
hc-install: will install terraform@1.0.0
failed to install terraform@1.0.0: no ZIP archive found for terraform 1.0.0 darwin/arm64
exit status 1
```