### PR TITLE
[chore] Fix minor lint issue

### DIFF
--- a/fs/fs_unix.go
+++ b/fs/fs_unix.go
@@ -16,9 +16,7 @@ import (
 func lookupDirs(extraDirs []string) []string {
 	pathVar := os.Getenv("PATH")
 	dirs := filepath.SplitList(pathVar)
-	for _, ep := range extraDirs {
-		dirs = append(dirs, ep)
-	}
+	dirs = append(dirs, extraDirs...)
 	return dirs
 }
 


### PR DESCRIPTION
## What

```
S1011: should replace loop with `dirs = append(dirs, extraDirs...)` (gosimple)
```