### PR TITLE
Add support for custom download URLs

### DIFF
--- a/cmd/hc-install/cmd_install.go
+++ b/cmd/hc-install/cmd_install.go
@@ -43,8 +43,6 @@ Usage: hc-install install [options] -version <version> <product>
               Defaults to current working directory.
     -log-file Path to file where logs will be written. /dev/stdout
               or /dev/stderr can be used to log to STDOUT/STDERR.
-	-custom-url  Custom URL to download the product from.
-			  URL Endpoint must have same structure as HashiCorp releases.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -54,7 +52,6 @@ func (c *InstallCommand) Run(args []string) int {
 		version        string
 		installDirPath string
 		logFilePath    string
-		customURL      string
 	)
 
 	fs := flag.NewFlagSet("install", flag.ExitOnError)
@@ -62,7 +59,6 @@ func (c *InstallCommand) Run(args []string) int {
 	fs.StringVar(&version, "version", "", "version of product to install")
 	fs.StringVar(&installDirPath, "path", "", "path to directory where production will be installed")
 	fs.StringVar(&logFilePath, "log-file", "", "path to file where logs will be written")
-	fs.StringVar(&customURL, "custom-url", "", "custom URL to download the product from")
 
 	if err := fs.Parse(args); err != nil {
 		return 1
@@ -103,7 +99,7 @@ Option flags must be provided before the positional argument`)
 		logger = log.New(f, "[DEBUG] ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds)
 	}
 
-	installedPath, err := c.install(product, version, installDirPath, customURL, logger)
+	installedPath, err := c.install(product, version, installDirPath, logger)
 	if err != nil {
 		msg := fmt.Sprintf("failed to install %s@%s: %v", product, version, err)
 		c.Ui.Error(msg)
@@ -114,7 +110,7 @@ Option flags must be provided before the positional argument`)
 	return 0
 }
 
-func (c *InstallCommand) install(project, tag, installDirPath, customURL string, logger *log.Logger) (string, error) {
+func (c *InstallCommand) install(project, tag, installDirPath string, logger *log.Logger) (string, error) {
 	msg := fmt.Sprintf("hc-install: will install %s@%s", project, tag)
 	c.Ui.Info(msg)
 
@@ -137,7 +133,6 @@ func (c *InstallCommand) install(project, tag, installDirPath, customURL string,
 		},
 		Version:    v,
 		InstallDir: installDirPath,
-		CustomURL:  customURL,
 	}
 
 	ctx := context.Background()

--- a/cmd/hc-install/cmd_install.go
+++ b/cmd/hc-install/cmd_install.go
@@ -43,6 +43,8 @@ Usage: hc-install install [options] -version <version> <product>
               Defaults to current working directory.
     -log-file Path to file where logs will be written. /dev/stdout
               or /dev/stderr can be used to log to STDOUT/STDERR.
+	-custom-url  Custom URL to download the product from.
+			  URL Endpoint must have same structure as HashiCorp releases.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -52,6 +54,7 @@ func (c *InstallCommand) Run(args []string) int {
 		version        string
 		installDirPath string
 		logFilePath    string
+		customURL      string
 	)
 
 	fs := flag.NewFlagSet("install", flag.ExitOnError)
@@ -59,6 +62,7 @@ func (c *InstallCommand) Run(args []string) int {
 	fs.StringVar(&version, "version", "", "version of product to install")
 	fs.StringVar(&installDirPath, "path", "", "path to directory where production will be installed")
 	fs.StringVar(&logFilePath, "log-file", "", "path to file where logs will be written")
+	fs.StringVar(&customURL, "custom-url", "", "custom URL to download the product from")
 
 	if err := fs.Parse(args); err != nil {
 		return 1
@@ -99,7 +103,7 @@ Option flags must be provided before the positional argument`)
 		logger = log.New(f, "[DEBUG] ", log.LstdFlags|log.Lshortfile|log.Lmicroseconds)
 	}
 
-	installedPath, err := c.install(product, version, installDirPath, logger)
+	installedPath, err := c.install(product, version, installDirPath, customURL, logger)
 	if err != nil {
 		msg := fmt.Sprintf("failed to install %s@%s: %v", product, version, err)
 		c.Ui.Error(msg)
@@ -110,7 +114,7 @@ Option flags must be provided before the positional argument`)
 	return 0
 }
 
-func (c *InstallCommand) install(project, tag, installDirPath string, logger *log.Logger) (string, error) {
+func (c *InstallCommand) install(project, tag, installDirPath, customURL string, logger *log.Logger) (string, error) {
 	msg := fmt.Sprintf("hc-install: will install %s@%s", project, tag)
 	c.Ui.Info(msg)
 
@@ -133,6 +137,7 @@ func (c *InstallCommand) install(project, tag, installDirPath string, logger *lo
 		},
 		Version:    v,
 		InstallDir: installDirPath,
+		CustomURL:  customURL,
 	}
 
 	ctx := context.Background()

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -63,8 +63,7 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 	archiveURL := pb.URL
 	if d.BaseURL != "" {
 		// If custom URL is set, use that instead of the one from the JSON.
-		// If using a custom URL, it may be because access to the HashiCorp Releases API is restricted.
-		// Also ensure that absolute download links from mocked responses are still pointing to the mock server if one is set.
+		// Also ensures that absolute download links from mocked responses are still pointing to the mock server if one is set.
 		baseURL, err := url.Parse(d.BaseURL)
 		if err != nil {
 			return "", err

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -62,8 +62,9 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	archiveURL := pb.URL
 	if d.BaseURL != "" {
-		// ensure that absolute download links from mocked responses
-		// are still pointing to the mock server if one is set
+		// If custom URL is set, use that instead of the one from the JSON.
+		// If using a custom URL, it may be because access to the HashiCorp Releases API is restricted.
+		// Also ensure that absolute download links from mocked responses are still pointing to the mock server if one is set.
 		baseURL, err := url.Parse(d.BaseURL)
 		if err != nil {
 			return "", err

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -63,7 +63,8 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 	archiveURL := pb.URL
 	if d.BaseURL != "" {
 		// If custom URL is set, use that instead of the one from the JSON.
-		// Also ensures that absolute download links from mocked responses are still pointing to the mock server if one is set.
+		// Also ensures that absolute download links from mocked responses
+		// are still pointing to the mock server if one is set.
 		baseURL, err := url.Parse(d.BaseURL)
 		if err != nil {
 			return "", err

--- a/releases/exact_version.go
+++ b/releases/exact_version.go
@@ -39,6 +39,7 @@ type ExactVersion struct {
 	// CustomURL is an optional field that specifies a custom URL to download the product from.
 	// This can be useful in environments where access to the default HashiCorp releases site (releases.hashicorp.com) is blocked.
 	// If CustomURL is set, the product will be downloaded from this URL instead of the default site.
+	// Note: The directory structure of the custom URL must match the HashiCorp releases site (including the index.json files).
 	CustomURL     string
 	logger        *log.Logger
 	pathsToRemove []string

--- a/releases/exact_version.go
+++ b/releases/exact_version.go
@@ -36,7 +36,10 @@ type ExactVersion struct {
 	// instead of built-in pubkey to verify signature of downloaded checksums
 	ArmoredPublicKey string
 
-	apiBaseURL    string
+	// CustomURL is an optional field that specifies a custom URL to download the product from.
+	// This can be useful in environments where access to the default HashiCorp releases site (releases.hashicorp.com) is blocked.
+	// If CustomURL is set, the product will be downloaded from this URL instead of the default site.
+	CustomURL     string
 	logger        *log.Logger
 	pathsToRemove []string
 }
@@ -102,8 +105,8 @@ func (ev *ExactVersion) Install(ctx context.Context) (string, error) {
 	ev.log().Printf("will install into dir at %s", dstDir)
 
 	rels := rjson.NewReleases()
-	if ev.apiBaseURL != "" {
-		rels.BaseURL = ev.apiBaseURL
+	if ev.CustomURL != "" {
+		rels.BaseURL = ev.CustomURL
 	}
 	rels.SetLogger(ev.log())
 	installVersion := ev.Version
@@ -124,8 +127,8 @@ func (ev *ExactVersion) Install(ctx context.Context) (string, error) {
 	if ev.ArmoredPublicKey != "" {
 		d.ArmoredPublicKey = ev.ArmoredPublicKey
 	}
-	if ev.apiBaseURL != "" {
-		d.BaseURL = ev.apiBaseURL
+	if ev.CustomURL != "" {
+		d.BaseURL = ev.CustomURL
 	}
 
 	licenseDir := ""

--- a/releases/exact_version.go
+++ b/releases/exact_version.go
@@ -36,11 +36,10 @@ type ExactVersion struct {
 	// instead of built-in pubkey to verify signature of downloaded checksums
 	ArmoredPublicKey string
 
-	// CustomURL is an optional field that specifies a custom URL to download the product from.
-	// This can be useful in environments where access to the default HashiCorp releases site (releases.hashicorp.com) is blocked.
-	// If CustomURL is set, the product will be downloaded from this URL instead of the default site.
+	// ApiBaseURL is an optional field that specifies a custom URL to download the product from.
+	// If ApiBaseURL is set, the product will be downloaded from this base URL instead of the default site.
 	// Note: The directory structure of the custom URL must match the HashiCorp releases site (including the index.json files).
-	CustomURL     string
+	ApiBaseURL    string
 	logger        *log.Logger
 	pathsToRemove []string
 }
@@ -106,8 +105,8 @@ func (ev *ExactVersion) Install(ctx context.Context) (string, error) {
 	ev.log().Printf("will install into dir at %s", dstDir)
 
 	rels := rjson.NewReleases()
-	if ev.CustomURL != "" {
-		rels.BaseURL = ev.CustomURL
+	if ev.ApiBaseURL != "" {
+		rels.BaseURL = ev.ApiBaseURL
 	}
 	rels.SetLogger(ev.log())
 	installVersion := ev.Version
@@ -128,8 +127,8 @@ func (ev *ExactVersion) Install(ctx context.Context) (string, error) {
 	if ev.ArmoredPublicKey != "" {
 		d.ArmoredPublicKey = ev.ArmoredPublicKey
 	}
-	if ev.CustomURL != "" {
-		d.BaseURL = ev.CustomURL
+	if ev.ApiBaseURL != "" {
+		d.BaseURL = ev.ApiBaseURL
 	}
 
 	licenseDir := ""

--- a/releases/latest_version.go
+++ b/releases/latest_version.go
@@ -39,6 +39,7 @@ type LatestVersion struct {
 	// CustomURL is an optional field that specifies a custom URL to download the product from.
 	// This can be useful in environments where access to the default HashiCorp releases site (releases.hashicorp.com) is blocked.
 	// If CustomURL is set, the product will be downloaded from this URL instead of the default site.
+	// Note: The directory structure of the custom URL must match the HashiCorp releases site (including the index.json files).
 	CustomURL     string
 	logger        *log.Logger
 	pathsToRemove []string

--- a/releases/latest_version.go
+++ b/releases/latest_version.go
@@ -36,11 +36,10 @@ type LatestVersion struct {
 	// instead of built-in pubkey to verify signature of downloaded checksums
 	ArmoredPublicKey string
 
-	// CustomURL is an optional field that specifies a custom URL to download the product from.
-	// This can be useful in environments where access to the default HashiCorp releases site (releases.hashicorp.com) is blocked.
-	// If CustomURL is set, the product will be downloaded from this URL instead of the default site.
+	// ApiBaseURL is an optional field that specifies a custom URL to download the product from.
+	// If ApiBaseURL is set, the product will be downloaded from this base URL instead of the default site.
 	// Note: The directory structure of the custom URL must match the HashiCorp releases site (including the index.json files).
-	CustomURL     string
+	ApiBaseURL    string
 	logger        *log.Logger
 	pathsToRemove []string
 }
@@ -102,8 +101,8 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	lv.log().Printf("will install into dir at %s", dstDir)
 
 	rels := rjson.NewReleases()
-	if lv.CustomURL != "" {
-		rels.BaseURL = lv.CustomURL
+	if lv.ApiBaseURL != "" {
+		rels.BaseURL = lv.ApiBaseURL
 	}
 	rels.SetLogger(lv.log())
 	versions, err := rels.ListProductVersions(ctx, lv.Product.Name)
@@ -129,8 +128,8 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	if lv.ArmoredPublicKey != "" {
 		d.ArmoredPublicKey = lv.ArmoredPublicKey
 	}
-	if lv.CustomURL != "" {
-		d.BaseURL = lv.CustomURL
+	if lv.ApiBaseURL != "" {
+		d.BaseURL = lv.ApiBaseURL
 	}
 	licenseDir := ""
 	if lv.Enterprise != nil {

--- a/releases/latest_version.go
+++ b/releases/latest_version.go
@@ -36,7 +36,10 @@ type LatestVersion struct {
 	// instead of built-in pubkey to verify signature of downloaded checksums
 	ArmoredPublicKey string
 
-	apiBaseURL    string
+	// CustomURL is an optional field that specifies a custom URL to download the product from.
+	// This can be useful in environments where access to the default HashiCorp releases site (releases.hashicorp.com) is blocked.
+	// If CustomURL is set, the product will be downloaded from this URL instead of the default site.
+	CustomURL     string
 	logger        *log.Logger
 	pathsToRemove []string
 }
@@ -98,8 +101,8 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	lv.log().Printf("will install into dir at %s", dstDir)
 
 	rels := rjson.NewReleases()
-	if lv.apiBaseURL != "" {
-		rels.BaseURL = lv.apiBaseURL
+	if lv.CustomURL != "" {
+		rels.BaseURL = lv.CustomURL
 	}
 	rels.SetLogger(lv.log())
 	versions, err := rels.ListProductVersions(ctx, lv.Product.Name)
@@ -125,8 +128,8 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	if lv.ArmoredPublicKey != "" {
 		d.ArmoredPublicKey = lv.ArmoredPublicKey
 	}
-	if lv.apiBaseURL != "" {
-		d.BaseURL = lv.apiBaseURL
+	if lv.CustomURL != "" {
+		d.BaseURL = lv.CustomURL
 	}
 	licenseDir := ""
 	if lv.Enterprise != nil {

--- a/releases/releases_test.go
+++ b/releases/releases_test.go
@@ -61,7 +61,7 @@ func TestLatestVersion_basic(t *testing.T) {
 	lv := &LatestVersion{
 		Product:          product.Terraform,
 		ArmoredPublicKey: getTestPubKey(t),
-		apiBaseURL:       testutil.NewTestServer(t, mockApiRoot).URL,
+		CustomURL:        testutil.NewTestServer(t, mockApiRoot).URL,
 	}
 	lv.SetLogger(testutil.TestLogger())
 
@@ -95,7 +95,7 @@ func TestLatestVersion_prereleases(t *testing.T) {
 		Product:            product.Terraform,
 		IncludePrereleases: true,
 		ArmoredPublicKey:   getTestPubKey(t),
-		apiBaseURL:         testutil.NewTestServer(t, mockApiRoot).URL,
+		CustomURL:          testutil.NewTestServer(t, mockApiRoot).URL,
 	}
 	lv.SetLogger(testutil.TestLogger())
 
@@ -167,7 +167,7 @@ func BenchmarkExactVersion(b *testing.B) {
 			Product:          product.Terraform,
 			Version:          version.Must(version.NewVersion("0.14.11")),
 			ArmoredPublicKey: getTestPubKey(b),
-			apiBaseURL:       testutil.NewTestServer(b, mockApiRoot).URL,
+			CustomURL:        testutil.NewTestServer(b, mockApiRoot).URL,
 			InstallDir:       installDir,
 		}
 		ev.SetLogger(testutil.TestLogger())

--- a/releases/releases_test.go
+++ b/releases/releases_test.go
@@ -61,7 +61,7 @@ func TestLatestVersion_basic(t *testing.T) {
 	lv := &LatestVersion{
 		Product:          product.Terraform,
 		ArmoredPublicKey: getTestPubKey(t),
-		CustomURL:        testutil.NewTestServer(t, mockApiRoot).URL,
+		ApiBaseURL:       testutil.NewTestServer(t, mockApiRoot).URL,
 	}
 	lv.SetLogger(testutil.TestLogger())
 
@@ -95,7 +95,7 @@ func TestLatestVersion_prereleases(t *testing.T) {
 		Product:            product.Terraform,
 		IncludePrereleases: true,
 		ArmoredPublicKey:   getTestPubKey(t),
-		CustomURL:          testutil.NewTestServer(t, mockApiRoot).URL,
+		ApiBaseURL:         testutil.NewTestServer(t, mockApiRoot).URL,
 	}
 	lv.SetLogger(testutil.TestLogger())
 
@@ -167,7 +167,7 @@ func BenchmarkExactVersion(b *testing.B) {
 			Product:          product.Terraform,
 			Version:          version.Must(version.NewVersion("0.14.11")),
 			ArmoredPublicKey: getTestPubKey(b),
-			CustomURL:        testutil.NewTestServer(b, mockApiRoot).URL,
+			ApiBaseURL:       testutil.NewTestServer(b, mockApiRoot).URL,
 			InstallDir:       installDir,
 		}
 		ev.SetLogger(testutil.TestLogger())


### PR DESCRIPTION
## What

Some environments do not have access to `releases.hashicorp.com`.

This PR adds a `CustomURL` var to `LatestVersion` and `ExactVersion`

This can be used in environments where calls to https://releases.hashicorp.com/ are firewalled for example.

## Requirements for use

Naming/dir structure would need to be the same as the Hashicorp version. There would also need to be `index.json` files within both the Version dir (`<url>/terraform/<version>/index.json` - [example](https://releases.hashicorp.com/terraform/1.8.2/index.json)) and Product dir (`<url>/terraform/index.json` - [example](https://releases.hashicorp.com/terraform/index.json)) as `hc-install` parses these for it's usage.

## Example usage

Atlantis is currently debating using `hc-install`. It would work for "default URL" downloads, but Atlantis also supports downloads from custom URL's in-case the HashiCorp releases page is firewalled (e.g. a need to use a local download server hosting the same as the Hashicorp Releases for example)

Atlantis already expects any custom download URL to have the same directory structure and files as the Hashicorp Releases URL - https://github.com/runatlantis/atlantis/blob/b7d3ae9c64c8ee93126d2cf16f20b9960b280b43/server/core/terraform/terraform_client.go#L560-L567

This PR isn't specific to Atlantis or anything - it just allows for a different URL for downloads.
