### PR TITLE
Ensure license file gets packaged along w/ the CLI binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,13 @@ jobs:
           reproducible: report
           instructions: |
             go build -trimpath -ldflags "-s -w" -o "$BIN_PATH" ./cmd/hc-install
-
+            cp LICENSE "$TARGET_DIR/LICENSE.txt"
+      - name: Copy license file to config_dir # for Linux packages
+        if: ${{ matrix.goos == 'linux' }}
+        env:
+          LICENSE_DIR: ".release/linux/package/usr/share/doc/${{ env.PKG_NAME }}"
+        run: |
+          mkdir -p "$LICENSE_DIR" && cp LICENSE "$LICENSE_DIR/LICENSE.txt"
       - name: Package
         if: ${{ matrix.goos == 'linux' }}
         uses: hashicorp/actions-packaging-linux@v1
@@ -112,6 +118,7 @@ jobs:
           binary: "dist/${{ env.PKG_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"
+          config_dir: ".release/linux/package/"
 
       - name: Set Package Names
         if: ${{ matrix.goos == 'linux' }}


### PR DESCRIPTION
This is to satisfy requirements from Legal, similar to

- https://github.com/hashicorp/terraform/pull/34977
- https://github.com/hashicorp/nomad/pull/20345

Importantly, this does _not_ address the issue tracked under https://github.com/hashicorp/hc-install/issues/197 but just ensures that `hc-install` CLI tool in itself has its own license file packaged with it in the ZIP archive and in the Linux packages we distribute.