### PR TITLE
Ensure license files are tracked during installation so they can be removed

### DIFF
--- a/checkpoint/latest_version.go
+++ b/checkpoint/latest_version.go
@@ -126,9 +126,9 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	if lv.ArmoredPublicKey != "" {
 		d.ArmoredPublicKey = lv.ArmoredPublicKey
 	}
-	zipFilePath, err := d.DownloadAndUnpack(ctx, pv, dstDir, "")
-	if zipFilePath != "" {
-		lv.pathsToRemove = append(lv.pathsToRemove, zipFilePath)
+	up, err := d.DownloadAndUnpack(ctx, pv, dstDir, "")
+	if up != nil {
+		lv.pathsToRemove = append(lv.pathsToRemove, up.PathsToRemove...)
 	}
 	if err != nil {
 		return "", err

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -219,11 +219,13 @@ func contentTypeIsZip(contentType string) bool {
 	return false
 }
 
-// Enterprise products have a few additional license files
-// that need to be extracted to a separate directory
+// Product archives may have a few license files
+// which may be extracted to a separate directory
+// and may need to be tracked for later cleanup.
 var licenseFiles = []string{
 	"EULA.txt",
 	"TermsOfEvaluation.txt",
+	"LICENSE.txt",
 }
 
 func isLicenseFile(filename string) bool {

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -181,6 +181,11 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 		d.Logger.Printf("unpacking %s to %s", f.Name, dstDir)
 		dstPath := filepath.Join(dstDir, f.Name)
+
+		if isLicenseFile(f.Name) {
+			up.PathsToRemove = append(up.PathsToRemove, dstPath)
+		}
+
 		dstFile, err := os.Create(dstPath)
 		if err != nil {
 			return up, err

--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -28,14 +28,18 @@ type Downloader struct {
 	BaseURL          string
 }
 
-func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, binDir string, licenseDir string) (zipFilePath string, err error) {
+type UnpackedProduct struct {
+	PathsToRemove []string
+}
+
+func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, binDir string, licenseDir string) (up *UnpackedProduct, err error) {
 	if len(pv.Builds) == 0 {
-		return "", fmt.Errorf("no builds found for %s %s", pv.Name, pv.Version)
+		return nil, fmt.Errorf("no builds found for %s %s", pv.Name, pv.Version)
 	}
 
 	pb, ok := pv.Builds.FilterBuild(runtime.GOOS, runtime.GOARCH, "zip")
 	if !ok {
-		return "", fmt.Errorf("no ZIP archive found for %s %s %s/%s",
+		return nil, fmt.Errorf("no ZIP archive found for %s %s %s/%s",
 			pv.Name, pv.Version, runtime.GOOS, runtime.GOARCH)
 	}
 
@@ -49,12 +53,12 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 		}
 		verifiedChecksums, err := v.DownloadAndVerifyChecksums(ctx)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		var ok bool
 		verifiedChecksum, ok = verifiedChecksums[pb.Filename]
 		if !ok {
-			return "", fmt.Errorf("no checksum found for %q", pb.Filename)
+			return nil, fmt.Errorf("no checksum found for %q", pb.Filename)
 		}
 	}
 
@@ -67,12 +71,12 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 		// are still pointing to the mock server if one is set.
 		baseURL, err := url.Parse(d.BaseURL)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		u, err := url.Parse(archiveURL)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		u.Scheme = baseURL.Scheme
 		u.Host = baseURL.Host
@@ -83,15 +87,15 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, archiveURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create request for %q: %w", archiveURL, err)
+		return nil, fmt.Errorf("failed to create request for %q: %w", archiveURL, err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if resp.StatusCode != 200 {
-		return "", fmt.Errorf("failed to download ZIP archive from %q: %s", archiveURL, resp.Status)
+		return nil, fmt.Errorf("failed to download ZIP archive from %q: %s", archiveURL, resp.Status)
 	}
 
 	defer resp.Body.Close()
@@ -100,7 +104,7 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	contentType := resp.Header.Get("content-type")
 	if !contentTypeIsZip(contentType) {
-		return "", fmt.Errorf("unexpected content-type: %s (expected any of %q)",
+		return nil, fmt.Errorf("unexpected content-type: %s (expected any of %q)",
 			contentType, zipMimeTypes)
 	}
 
@@ -108,10 +112,13 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	pkgFile, err := os.CreateTemp("", pb.Filename)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer pkgFile.Close()
 	pkgFilePath, err := filepath.Abs(pkgFile.Name())
+
+	up = &UnpackedProduct{}
+	up.PathsToRemove = append(up.PathsToRemove, pkgFilePath)
 
 	d.Logger.Printf("copying %q (%d bytes) to %s", pb.Filename, expectedSize, pkgFile.Name())
 
@@ -123,12 +130,12 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 		bytesCopied, err = io.Copy(h, r)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
 		calculatedSum := h.Sum(nil)
 		if !bytes.Equal(calculatedSum, verifiedChecksum) {
-			return pkgFilePath, fmt.Errorf(
+			return up, fmt.Errorf(
 				"checksum mismatch (expected: %x, got: %x)",
 				verifiedChecksum, calculatedSum,
 			)
@@ -136,14 +143,14 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 	} else {
 		bytesCopied, err = io.Copy(pkgFile, pkgReader)
 		if err != nil {
-			return pkgFilePath, err
+			return up, err
 		}
 	}
 
 	d.Logger.Printf("copied %d bytes to %s", bytesCopied, pkgFile.Name())
 
 	if expectedSize != 0 && bytesCopied != int64(expectedSize) {
-		return pkgFilePath, fmt.Errorf(
+		return up, fmt.Errorf(
 			"unexpected size (downloaded: %d, expected: %d)",
 			bytesCopied, expectedSize,
 		)
@@ -151,7 +158,7 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 
 	r, err := zip.OpenReader(pkgFile.Name())
 	if err != nil {
-		return pkgFilePath, err
+		return up, err
 	}
 	defer r.Close()
 
@@ -163,7 +170,7 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 		}
 		srcFile, err := f.Open()
 		if err != nil {
-			return pkgFilePath, err
+			return up, err
 		}
 
 		// Determine the appropriate destination file path
@@ -176,18 +183,18 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 		dstPath := filepath.Join(dstDir, f.Name)
 		dstFile, err := os.Create(dstPath)
 		if err != nil {
-			return pkgFilePath, err
+			return up, err
 		}
 
 		_, err = io.Copy(dstFile, srcFile)
 		if err != nil {
-			return pkgFilePath, err
+			return up, err
 		}
 		srcFile.Close()
 		dstFile.Close()
 	}
 
-	return pkgFilePath, nil
+	return up, nil
 }
 
 // The production release site uses consistent single mime type

--- a/releases/exact_version.go
+++ b/releases/exact_version.go
@@ -135,9 +135,9 @@ func (ev *ExactVersion) Install(ctx context.Context) (string, error) {
 	if ev.Enterprise != nil {
 		licenseDir = ev.Enterprise.LicenseDir
 	}
-	zipFilePath, err := d.DownloadAndUnpack(ctx, pv, dstDir, licenseDir)
-	if zipFilePath != "" {
-		ev.pathsToRemove = append(ev.pathsToRemove, zipFilePath)
+	up, err := d.DownloadAndUnpack(ctx, pv, dstDir, licenseDir)
+	if up != nil {
+		ev.pathsToRemove = append(ev.pathsToRemove, up.PathsToRemove...)
 	}
 	if err != nil {
 		return "", err

--- a/releases/latest_version.go
+++ b/releases/latest_version.go
@@ -135,9 +135,9 @@ func (lv *LatestVersion) Install(ctx context.Context) (string, error) {
 	if lv.Enterprise != nil {
 		licenseDir = lv.Enterprise.LicenseDir
 	}
-	zipFilePath, err := d.DownloadAndUnpack(ctx, versionToInstall, dstDir, licenseDir)
-	if zipFilePath != "" {
-		lv.pathsToRemove = append(lv.pathsToRemove, zipFilePath)
+	up, err := d.DownloadAndUnpack(ctx, versionToInstall, dstDir, licenseDir)
+	if up != nil {
+		lv.pathsToRemove = append(lv.pathsToRemove, up.PathsToRemove...)
 	}
 	if err != nil {
 		return "", err

--- a/releases/releases_test.go
+++ b/releases/releases_test.go
@@ -125,7 +125,7 @@ func TestLatestVersion_prereleases(t *testing.T) {
 func TestExactVersion(t *testing.T) {
 	testutil.EndToEndTest(t)
 
-	versionToInstall := version.Must(version.NewVersion("1.1.0"))
+	versionToInstall := version.Must(version.NewVersion("1.8.2"))
 	ev := &ExactVersion{
 		Product: product.Terraform,
 		Version: versionToInstall,
@@ -139,7 +139,14 @@ func TestExactVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Cleanup(func() { ev.Remove(ctx) })
+	licensePath := filepath.Join(filepath.Dir(execPath), "LICENSE.txt")
+	t.Cleanup(func() {
+		ev.Remove(ctx)
+		// check if license was deleted
+		if _, err := os.Stat(licensePath); !os.IsNotExist(err) {
+			t.Fatalf("license file not deleted at %q: %s", licensePath, err)
+		}
+	})
 
 	t.Logf("exec path of installed: %s", execPath)
 
@@ -151,6 +158,11 @@ func TestExactVersion(t *testing.T) {
 	if !versionToInstall.Equal(v) {
 		t.Fatalf("versions don't match (expected: %s, installed: %s)",
 			versionToInstall, v)
+	}
+
+	// check if license was copied
+	if _, err := os.Stat(licensePath); err != nil {
+		t.Fatalf("expected license file not found at %q: %s", licensePath, err)
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/hc-install/issues/197

--- 

The implementation has a few (intentional) side effects which may be worth calling out here:

 - We now treat all/any license files the same, be it Enterprise related files like `EULA.txt` or CE related files like `LICENSE.txt`. It keeps the implementation simple and I don't see harm in it.
 - When building the product from source, we also now copy the license file on a best effort basis, reflecting that the file name may not match `LICENSE.txt` but more often just `LICENSE`. The assumption I'm making there is that over time, those files would be renamed to `LICENSE.txt` and no _renaming_ would happen as part of a release. Again though - it's just best-effort basis that seemed relatively low effort.

### Out of scope

As the diff was growing larger I decided to keep the additional `LicenseDir` option out of scope for this PR but I'd be happy to address that in a separate PR. We agreed on the default behaviour anyway, so the future PR won't change that as it will be "opt in".