### PR TITLE
github: Set up Dependabot to manage HashiCorp-owned Actions versioning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
     labels:
       - dependencies
     # only update HashiCorp actions, external actions managed by TSCCR

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,21 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+    # only update HashiCorp actions, external actions managed by TSCCR
+    allow:
+      - dependency-name: hashicorp/*
+    groups:
+      github-actions-breaking:
+        update-types:
+          - major
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Set Product version
         id: set-product-version
-        uses: hashicorp/actions-set-product-version@v1
+        uses: hashicorp/actions-set-product-version@e2c49d61aff17b1280ddfe7bb031331d02ca0140 # v1.0.1
 
   generate-metadata-file:
     needs: set-product-version
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Generate metadata file
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@v1
+        uses: hashicorp/actions-generate-metadata@fdbc8803a0e53bcbb912ddeee3808329033d6357 # v1.1.1
         with:
           version: ${{ needs.set-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
@@ -106,7 +106,7 @@ jobs:
           mkdir -p "$LICENSE_DIR" && cp LICENSE "$LICENSE_DIR/LICENSE.txt"
       - name: Package
         if: ${{ matrix.goos == 'linux' }}
-        uses: hashicorp/actions-packaging-linux@v1
+        uses: hashicorp/actions-packaging-linux@0596d94121d44bd00463ac9d245efea64ee282d0 # v1.7
         with:
           name: ${{ github.event.repository.name }}
           description: "hc-install CLI allows installing multiple versions of HashiCorp products in automation"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: hashicorp/actions-go-build@v0.1.9
+      - uses: hashicorp/actions-go-build@e20c6be7bf010e40e930dab20e6da63176725ec1 # v0.1.9
         env:
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup bob
-        uses: hashicorp/action-setup-bob@v1
+        uses: hashicorp/action-setup-bob@3b8865c92994bc7e960441612e81f88a84d31a1a # v1.0.20
         with:
           github-token:
             ${{ secrets.BOB_GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
     needs: staging
     steps:
       - name: Setup bob
-        uses: hashicorp/action-setup-bob@v1
+        uses: hashicorp/action-setup-bob@3b8865c92994bc7e960441612e81f88a84d31a1a # v1.0.20
         with:
           github-token:
             ${{ secrets.BOB_GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Install copywrite
-        uses: hashicorp/setup-copywrite@v1.1.2
+        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
       - name: Validate Header Compliance
         run: copywrite headers --plan
 


### PR DESCRIPTION
This sets up Dependabot to manage version updates for HashiCorp-owned GitHub Actions; all other (third-party) version updates are already handled by HashiCorp's internal TSCCR tooling. TSCCR does not/cannot manage HashiCorp-owned Actions versioning which is why we need to bring in Dependabot to handle this component; see [this memo](https://hermes.hashicorp.services/document/151w0ldYS3Z3arAiSTRuFImV73VabC0rhZJPCv6fzl4Q) (internal HashiCorp link) for details.

This PR also pins all HashiCorp-owned Actions used in this repo to using SHA hashes which is considered a security best-practice these days. This will force Dependabot to continue with this convention, and it is smart enough to update the comment on each of these lines to let us know which is the actual version that's being used.