### PR TITLE
github: Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, 
+# they will be requested for review when someone opens a 
+# pull request.
+
+*       @hashicorp/terraform-core


### PR DESCRIPTION
Realized this repo was also missing a CODEOWNERS. Can/should there be anyone else on this list or is it really just the Core team? I see a couple of commits from bflad and from a couple of Nomad team engineers, but that's it.