### PR TITLE
[fix] include custom url's "path" when creating Archive URL

### DIFF
--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -244,11 +243,8 @@ func determineArchiveURL(archiveURL, baseURL string) (string, error) {
 		return "", err
 	}
 
-	// Preserve the path from the baseURL and append the path from the archiveURL.
-	newPath := path.Join(base.Path, strings.TrimPrefix(u.Path, "/"))
-	u.Scheme = base.Scheme
-	u.Host = base.Host
-	u.Path = newPath
+	// Use base URL path and append the path from the archive URL.
+	newArchiveURL := base.JoinPath(u.Path)
 
-	return u.String(), nil
+	return newArchiveURL.String(), nil
 }

--- a/internal/releasesjson/downloader_test.go
+++ b/internal/releasesjson/downloader_test.go
@@ -1,0 +1,44 @@
+package releasesjson
+
+import "testing"
+
+func TestDetermineArchiveURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		archiveURL string
+		baseURL    string
+		want       string
+	}{
+		{
+			name:       "with custom base URL + path",
+			archiveURL: "https://releases.hashicorp.com/terraform/1.8.2/terraform_1.8.2_darwin_amd64.zip",
+			baseURL:    "https://myartifactory.company.com/artifactory/hashicorp-remote",
+			want:       "https://myartifactory.company.com/artifactory/hashicorp-remote/terraform/1.8.2/terraform_1.8.2_darwin_amd64.zip",
+		},
+		{
+			name:       "with custom base URL + port + path",
+			archiveURL: "https://releases.hashicorp.com/terraform/1.8.2/terraform_1.8.2_darwin_amd64.zip",
+			baseURL:    "https://myartifactory.company.com:443/artifactory/hashicorp-remote",
+			want:       "https://myartifactory.company.com:443/artifactory/hashicorp-remote/terraform/1.8.2/terraform_1.8.2_darwin_amd64.zip",
+		},
+		{
+			name:       "without custom base URL",
+			archiveURL: "https://releases.hashicorp.com/terraform/1.8.2/terraform_1.8.2_darwin_amd64.zip",
+			baseURL:    "",
+			want:       "https://releases.hashicorp.com/terraform/1.8.2/terraform_1.8.2_darwin_amd64.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := determineArchiveURL(tt.archiveURL, tt.baseURL)
+			if err != nil {
+				t.Errorf("determineArchiveURL() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("determineArchiveURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/releasesjson/downloader_test.go
+++ b/internal/releasesjson/downloader_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package releasesjson
 
 import "testing"


### PR DESCRIPTION
## What

Currently when constructing the archive URL for download, only `Scheme` and `Host` are considered. This meams any `Path` within the custom URL is not used when constructing the Archive URL.

## References

closes https://github.com/runatlantis/atlantis/issues/4778