### PR TITLE
Nightly and PR builds: fix "no space left on device" on macOS runner

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -42,6 +42,13 @@ jobs:
           - ${{ needs.resolve-versions.outputs.oldstable }}
           - ${{ needs.resolve-versions.outputs.stable }}
     steps:
+    - name: Free up space on macOS runner
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        df -hI /dev/disk3s1s1
+        sudo rm -rf /Applications/Xcode*
+        df -hI /dev/disk3s1s1
+
     - name: Check out code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,12 @@ jobs:
           - ${{ needs.resolve-versions.outputs.oldstable }}
           - ${{ needs.resolve-versions.outputs.stable }}
     steps:
+    - name: Free up space on macOS runner
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        df -hI /dev/disk3s1s1
+        sudo rm -rf /Applications/Xcode*
+        df -hI /dev/disk3s1s1
 
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2


### PR DESCRIPTION
Fix https://github.com/hashicorp/hc-install/issues/244

Tested by running the nightly builds on this branch. All builds passed and the "free up space" step was skipped for non-macOS runners.