### PR TITLE
Add a catalog-info.yaml file for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+#
+# Intended for internal HashiCorp use only
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: hc-install
+  description: Go module for downloading or locating HashiCorp binaries
+  annotations:
+    github.com/project-slug: hashicorp/hc-install
+    jira/project-key: TF
+    jira/label: hc-install
+spec:
+  type: library
+  owner: terraform-core
+  lifecycle: production


### PR DESCRIPTION
Includes basic metadata for registering hc-install as a library component in our internal Backstage installation. See DW-481.