### PR TITLE
product: Add packer

### DIFF
--- a/build/git_revision_test.go
+++ b/build/git_revision_test.go
@@ -127,6 +127,35 @@ func TestGitRevision_vault(t *testing.T) {
 	}
 }
 
+func TestGitRevision_packer(t *testing.T) {
+	testutil.EndToEndTest(t)
+
+	gr := &GitRevision{Product: product.Packer}
+	gr.SetLogger(testutil.TestLogger())
+
+	ctx := context.Background()
+
+	execPath, err := gr.Build(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { gr.Remove(ctx) })
+
+	v, err := product.Packer.GetVersion(ctx, execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	latestConstraint, err := version.NewConstraint(">= 1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !latestConstraint.Check(v.Core()) {
+		t.Fatalf("versions don't match (expected: %s, installed: %s)",
+			latestConstraint, v)
+	}
+}
+
 func TestGitRevisionValidate(t *testing.T) {
 	t.Parallel()
 

--- a/product/packer.go
+++ b/product/packer.go
@@ -15,15 +15,15 @@ import (
 	"github.com/hashicorp/hc-install/internal/build"
 )
 
-var terraformVersionOutputRe = regexp.MustCompile(`Terraform ` + simpleVersionRe)
+var packerVersionOutputRe = regexp.MustCompile(`Packer ` + simpleVersionRe)
 
-var Terraform = Product{
-	Name: "terraform",
+var Packer = Product{
+	Name: "packer",
 	BinaryName: func() string {
 		if runtime.GOOS == "windows" {
-			return "terraform.exe"
+			return "packer.exe"
 		}
-		return "terraform"
+		return "packer"
 	},
 	GetVersion: func(ctx context.Context, path string) (*version.Version, error) {
 		cmd := exec.CommandContext(ctx, path, "version")
@@ -35,7 +35,7 @@ var Terraform = Product{
 
 		stdout := strings.TrimSpace(string(out))
 
-		submatches := terraformVersionOutputRe.FindStringSubmatch(stdout)
+		submatches := packerVersionOutputRe.FindStringSubmatch(stdout)
 		if len(submatches) != 2 {
 			return nil, fmt.Errorf("unexpected number of version matches %d for %s", len(submatches), stdout)
 		}
@@ -47,7 +47,7 @@ var Terraform = Product{
 		return v, err
 	},
 	BuildInstructions: &BuildInstructions{
-		GitRepoURL:    "https://github.com/hashicorp/terraform.git",
+		GitRepoURL:    "https://github.com/hashicorp/packer.git",
 		PreCloneCheck: &build.GoIsInstalled{},
 		Build:         &build.GoBuild{DetectVendoring: true},
 	},

--- a/product/product.go
+++ b/product/product.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+const simpleVersionRe = `v?(?P<version>[0-9]+(?:\.[0-9]+)*(?:-[A-Za-z0-9\.]+)?)`
+
 type Product struct {
 	// Name which identifies the product
 	// on releases.hashicorp.com and in Checkpoint


### PR DESCRIPTION
Closes https://github.com/hashicorp/hc-install/issues/4

We can always add more products but I added notes to the original issue next to major products to effectively shorten the list and pragmatically close that issue.