### PR TITLE
releasesjson: Always remove unpacked archive

### DIFF
--- a/internal/releasesjson/downloader.go
+++ b/internal/releasesjson/downloader.go
@@ -100,11 +100,18 @@ func (d *Downloader) DownloadAndUnpack(ctx context.Context, pv *ProductVersion, 
 	if err != nil {
 		return nil, err
 	}
-	defer pkgFile.Close()
-	pkgFilePath, err := filepath.Abs(pkgFile.Name())
+	defer func() {
+		pkgFile.Close()
+		filePath := pkgFile.Name()
+		err = os.Remove(filePath)
+		if err != nil {
+			d.Logger.Printf("failed to delete unpacked archive at %s: %s", filePath, err)
+			return
+		}
+		d.Logger.Printf("deleted unpacked archive at %s", filePath)
+	}()
 
 	up = &UnpackedProduct{}
-	up.PathsToRemove = append(up.PathsToRemove, pkgFilePath)
 
 	d.Logger.Printf("copying %q (%d bytes) to %s", pb.Filename, expectedSize, pkgFile.Name())
 


### PR DESCRIPTION
As mentioned in https://github.com/hashicorp/hc-install/issues/145 we never reuse the archive and so it makes sense to *always* remove it rather then collect it for removal by end-user via `Remove()` method.

This in turn reduces disk space in situations where it is important (outside of disposable CI environments).

Closes https://github.com/hashicorp/hc-install/issues/145