### PR TITLE
product: Use `version` json output (consul + terraform)

### DIFF
--- a/product/terraform.go
+++ b/product/terraform.go
@@ -5,6 +5,7 @@ package product
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -26,29 +27,60 @@ var Terraform = Product{
 		return "terraform"
 	},
 	GetVersion: func(ctx context.Context, path string) (*version.Version, error) {
-		cmd := exec.CommandContext(ctx, path, "version")
-
-		out, err := cmd.Output()
-		if err != nil {
-			return nil, err
+		v, err := terraformJsonVersion(ctx, path)
+		if err == nil {
+			return v, nil
 		}
 
-		stdout := strings.TrimSpace(string(out))
-
-		submatches := terraformVersionOutputRe.FindStringSubmatch(stdout)
-		if len(submatches) != 2 {
-			return nil, fmt.Errorf("unexpected number of version matches %d for %s", len(submatches), stdout)
-		}
-		v, err := version.NewVersion(submatches[1])
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse version %q: %w", submatches[1], err)
-		}
-
-		return v, err
+		// JSON output was added in 0.13.0
+		// See https://github.com/hashicorp/terraform/pull/25252
+		// We assume that error implies older version.
+		return legacyTerraformVersion(ctx, path)
 	},
 	BuildInstructions: &BuildInstructions{
 		GitRepoURL:    "https://github.com/hashicorp/terraform.git",
 		PreCloneCheck: &build.GoIsInstalled{},
 		Build:         &build.GoBuild{DetectVendoring: true},
 	},
+}
+
+type terraformJsonVersionOutput struct {
+	Version *version.Version `json:"terraform_version"`
+}
+
+func terraformJsonVersion(ctx context.Context, path string) (*version.Version, error) {
+	cmd := exec.CommandContext(ctx, path, "version", "-json")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	var vOut terraformJsonVersionOutput
+	err = json.Unmarshal(out, &vOut)
+	if err != nil {
+		return nil, err
+	}
+
+	return vOut.Version, nil
+}
+
+func legacyTerraformVersion(ctx context.Context, path string) (*version.Version, error) {
+	cmd := exec.CommandContext(ctx, path, "version")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	stdout := strings.TrimSpace(string(out))
+
+	submatches := terraformVersionOutputRe.FindStringSubmatch(stdout)
+	if len(submatches) != 2 {
+		return nil, fmt.Errorf("unexpected number of version matches %d for %s", len(submatches), stdout)
+	}
+	v, err := version.NewVersion(submatches[1])
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse version %q: %w", submatches[1], err)
+	}
+
+	return v, err
 }


### PR DESCRIPTION
Closes https://github.com/hashicorp/hc-install/issues/23

Other products do not seem to have `version` JSON output.

Existing tests will exercise the new codepath, although admittedly the legacy part will not be exercised. The difficulty with testing it is that older versions of Terraform and Consul aren't available on some OS/platform combinations like darwin/arm64.

I think the lack of testing is ok for now, in part because we'll gain some more debugging capabilities as part of https://github.com/hashicorp/hc-install/issues/46 hopefully.
