### PR TITLE
github: Use Dependabot to keep Actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
       interval: weekly
     labels:
       - dependencies
-    # only update HashiCorp actions, external actions managed by TSCCR
-    allow:
-      - dependency-name: hashicorp/*
     groups:
       github-actions-breaking:
         update-types:


### PR DESCRIPTION
Now that TSCCR has gone away, Security's recommendation is that we go back to using Dependabot to keep all GitHub Actions updated.