### PR TITLE
github: Pin workflows to patch versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: hashicorp/actions-go-build@37358f6098ef21b09542d84a9814ebb843aa4e3e # v1
+      - uses: hashicorp/actions-go-build@d2504eb37c72b06b618352881e3f1d7b563517c5 # v1.1.0
         env:
           BASE_VERSION: ${{ needs.set-product-version.outputs.product-base-version }}
           PRERELEASE_VERSION: ${{ needs.set-product-version.outputs.product-prerelease-version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup bob
-        uses: hashicorp/action-setup-bob@01076d9cc869139ac97693d0869f0e80a666cb3b # v2
+        uses: hashicorp/action-setup-bob@01076d9cc869139ac97693d0869f0e80a666cb3b # v2.1.1
         with:
           github-token:
             ${{ secrets.BOB_GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
     needs: staging
     steps:
       - name: Setup bob
-        uses: hashicorp/action-setup-bob@01076d9cc869139ac97693d0869f0e80a666cb3b # v2
+        uses: hashicorp/action-setup-bob@01076d9cc869139ac97693d0869f0e80a666cb3b # v2.1.1
         with:
           github-token:
             ${{ secrets.BOB_GITHUB_TOKEN }}


### PR DESCRIPTION
This is to ensure that future dependabot updates like https://github.com/hashicorp/hc-install/pull/310 avoid bumping to unreleased revisions. It's probably a dependabot bug anyway, or dependabot is confused about our strategy of maintaining `v1` as a separate tag from `v1.x.x`. Either way we already pin majority of workflows to patch so there is no reason not to do it for all.

The only one left is `hashicorp/actions-set-product-version` which does not seem to have any tags other than `v2` currently.

Closes https://github.com/hashicorp/hc-install/pull/310