### PR TITLE
github: Pin hashicorp/actions-set-product-version to a patch version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set Product version
         id: set-product-version
-        uses: hashicorp/actions-set-product-version@d9b52fb778068099ca4c5e28e1ca0fee2544e114 # v2
+        uses: hashicorp/actions-set-product-version@2ec1b51402b3070bccf7ca95306afbd039e574ff # v2.0.1
 
   generate-metadata-file:
     needs: set-product-version


### PR DESCRIPTION
This is a follow-up to https://github.com/hashicorp/hc-install/pull/311 as during the creation of that PR a patch version of that Action did not exist yet.