### PR TITLE
github: Make PR job names static

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       stable: ${{ steps.stable.outputs.go-version }}
 
   build:
-    name: build (go ${{ matrix.go_version }})
+    name: Build
     needs:
       - resolve-versions
     runs-on: ubuntu-latest
@@ -82,7 +82,7 @@ jobs:
         go build -v .
 
   test:
-    name: tests (${{ matrix.os }}, go ${{ matrix.go_version }})
+    name: Tests
     needs:
       - build
       - resolve-versions


### PR DESCRIPTION
This is to allow us to reference these jobs in branch protection feature of GitHub. i.e. to be able to say that passing tests/builds are required before merging. The current dynamic names would have all kinds of unfortunate consequences. There are [workarounds](https://github.com/orgs/community/discussions/33579) but I think I'd prefer to just not use dynamic names as the complexity of the workaround just wipes out the benefits.

I'm a bit puzzled about GitHub's design decision to pick the job's _name_ instead of the ID here but I suppose they had some valid reasons. 🤷🏻 

This also enables auto-merging in a safer way.
