### PR TITLE
github/build: Avoid double checkout to address "Duplicate header: Authorization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Set Product version
         id: set-product-version
         uses: hashicorp/actions-set-product-version@2ec1b51402b3070bccf7ca95306afbd039e574ff # v2.0.1
+        with:
+          checkout: false
 
   generate-metadata-file:
     needs: set-product-version


### PR DESCRIPTION
This is an attempt to address [this](https://github.com/hashicorp/hc-install/actions/runs/19640699876/job/56325617090) persistent error which came with the upgrade of actions/checkout to v6.

Some other repositories which I also upgraded do not seem to be showing the same error however so I suspect it may be a combination of factors and the version isn't necessarily broken.

--- 

I'm not 100% sure this will clear the error but it seems logical to me that we avoid checking out the repository twice in the same job.
https://github.com/hashicorp/actions-set-product-version/blob/c750991da28960275f70f7e33e47a68f42e4fce8/action.yml#L8-L12
