### PR TITLE
build/tests: Remove vault

### DIFF
--- a/build/git_revision_test.go
+++ b/build/git_revision_test.go
@@ -98,35 +98,6 @@ func TestGitRevision_consul(t *testing.T) {
 	}
 }
 
-func TestGitRevision_vault(t *testing.T) {
-	testutil.EndToEndTest(t)
-
-	gr := &GitRevision{Product: product.Vault}
-	gr.SetLogger(testutil.TestLogger())
-
-	ctx := context.Background()
-
-	execPath, err := gr.Build(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { gr.Remove(ctx) })
-
-	v, err := product.Vault.GetVersion(ctx, execPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	latestConstraint, err := version.NewConstraint(">= 1.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !latestConstraint.Check(v.Core()) {
-		t.Fatalf("versions don't match (expected: %s, installed: %s)",
-			latestConstraint, v)
-	}
-}
-
 func TestGitRevision_packer(t *testing.T) {
 	testutil.EndToEndTest(t)
 


### PR DESCRIPTION
This is to address the every day test failure caused by the recent Vault revisions requiring substantial disk space for finishing the build.

It appears the latest Vault binary takes about ~500 MB ... 🙈 

Most recent failure example:

```
2025/12/09 15:18:54 git_revision.go:197: building of vault finished
    git_revision_test.go:111: unable to build: exit status 1
        # github.com/microsoftgraph/msgraph-sdk-go/serviceprincipals
        compile: writing output: write $WORK/b1958/_pkg_.a: no space left on device
        github.com/microsoftgraph/msgraph-sdk-go/serviceprincipalswithappid: mkdir /tmp/go-build1109773366/b1959/: no space left on device
        github.com/microsoftgraph/msgraph-sdk-go/shares: mkdir /tmp/go-build1109773366/b1960/: no space left on device
        # github.com/microsoftgraph/msgraph-sdk-go/groups
        compile: writing output: write $WORK/b1929/_pkg_.a: no space left on device
        error writing long arguments to response file: write /tmp/args3406408426: no space left on device
```

I have considered increasing the capacity of the CI instances but decided against it because it only postpones the problem and more importantly we do not need to be building Vault specifically to test the `build` package functionality - the other tests featuring other products already test it pretty thoroughly.