### PR TITLE
build: Add logging to understand Go version discrepancies

### DIFF
--- a/internal/build/go_build.go
+++ b/internal/build/go_build.go
@@ -128,7 +128,7 @@ func (gb *GoBuild) ensureRequiredGoVersion(ctx context.Context, repoDir string) 
 		installedVersion = goVersion
 	}
 
-	if requiredVersion, ok := guessRequiredGoVersion(repoDir); ok {
+	if requiredVersion, ok := gb.guessRequiredGoVersion(repoDir); ok {
 		gb.logger.Printf("attempting to satisfy guessed Go requirement %s", requiredVersion)
 		goVersion, err := GetGoVersion(ctx)
 		if err != nil {
@@ -158,7 +158,7 @@ func (gb *GoBuild) ensureRequiredGoVersion(ctx context.Context, repoDir string) 
 // e.g. to remove any version installed temporarily per requirements
 type CleanupFunc func(context.Context)
 
-func guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
+func (gb *GoBuild) guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
 	goEnvFile := filepath.Join(repoDir, ".go-version")
 	if fi, err := os.Stat(goEnvFile); err == nil && !fi.IsDir() {
 		b, err := os.ReadFile(goEnvFile)
@@ -169,6 +169,7 @@ func guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
 		if err != nil {
 			return nil, false
 		}
+		gb.logger.Printf("found Go version %s in .go-version", requiredVersion)
 		return requiredVersion, true
 	}
 
@@ -189,6 +190,7 @@ func guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
 		if err != nil {
 			return nil, false
 		}
+		gb.logger.Printf("found Go version %s in go.mod", requiredVersion)
 		return requiredVersion, true
 	}
 


### PR DESCRIPTION
## Description

There is a discrepancy between a version declared in `.go-version` and `go.mod` which was recently introduced in Consul by accident.

This was surfaced as a test failure [here](https://github.com/hashicorp/hc-install/actions/runs/24241131489/job/70775820794?pr=365#step:6:113).

Perhaps we could be comparing the two versions and prefer `go.mod` if it's higher but such a situation should never happen to begin with. i.e. `.go-version` should always be compatible with `.go-version` as that communicates preference, whereas `go.mod` communicates compatibility.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
