### PR TITLE
build: Prefer go.mod if Go versions mismatch

### DIFF
--- a/internal/build/go_build.go
+++ b/internal/build/go_build.go
@@ -128,7 +128,7 @@ func (gb *GoBuild) ensureRequiredGoVersion(ctx context.Context, repoDir string) 
 		installedVersion = goVersion
 	}
 
-	if requiredVersion, ok := guessRequiredGoVersion(repoDir); ok {
+	if requiredVersion, ok := gb.guessRequiredGoVersion(repoDir); ok {
 		gb.logger.Printf("attempting to satisfy guessed Go requirement %s", requiredVersion)
 		goVersion, err := GetGoVersion(ctx)
 		if err != nil {
@@ -158,7 +158,7 @@ func (gb *GoBuild) ensureRequiredGoVersion(ctx context.Context, repoDir string) 
 // e.g. to remove any version installed temporarily per requirements
 type CleanupFunc func(context.Context)
 
-func guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
+func (gb *GoBuild) guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
 	goEnvFile := filepath.Join(repoDir, ".go-version")
 	if fi, err := os.Stat(goEnvFile); err == nil && !fi.IsDir() {
 		b, err := os.ReadFile(goEnvFile)
@@ -169,6 +169,7 @@ func guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
 		if err != nil {
 			return nil, false
 		}
+		gb.logger.Printf("found Go version %s in .go-version", requiredVersion)
 		return requiredVersion, true
 	}
 
@@ -189,6 +190,7 @@ func guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
 		if err != nil {
 			return nil, false
 		}
+		gb.logger.Printf("found Go version %s in go.mod", requiredVersion)
 		return requiredVersion, true
 	}
 

--- a/internal/build/go_build.go
+++ b/internal/build/go_build.go
@@ -159,6 +159,39 @@ func (gb *GoBuild) ensureRequiredGoVersion(ctx context.Context, repoDir string) 
 type CleanupFunc func(context.Context)
 
 func (gb *GoBuild) guessRequiredGoVersion(repoDir string) (*version.Version, bool) {
+	goEnvVersion, goEnvFound := readGoEnvVersion(repoDir)
+	if goEnvFound {
+		gb.logger.Printf("found Go version %s in .go-version", goEnvVersion)
+	}
+
+	goModVersion, goModFound := readGoModVersion(repoDir)
+	if goModFound {
+		gb.logger.Printf("found Go version %s in go.mod", goModVersion)
+	}
+
+	// unlikely case for modern Go codebases of go.mod missing
+	if !goModFound && goEnvFound {
+		return goEnvVersion, true
+	}
+
+	if goModFound && !goEnvFound {
+		return goModVersion, true
+	}
+
+	if goEnvFound && goModFound {
+		// only use .go-version if it's compatible with go.mod
+		if goEnvVersion.GreaterThanOrEqual(goModVersion) {
+			return goEnvVersion, true
+		}
+		gb.logger.Printf("found Go versions mismatch (.go-version: %s, go.mod: %s), choosing go.mod (%s)",
+			goEnvVersion, goModVersion, goModVersion)
+		return goModVersion, true
+	}
+
+	return nil, false
+}
+
+func readGoEnvVersion(repoDir string) (*version.Version, bool) {
 	goEnvFile := filepath.Join(repoDir, ".go-version")
 	if fi, err := os.Stat(goEnvFile); err == nil && !fi.IsDir() {
 		b, err := os.ReadFile(goEnvFile)
@@ -169,10 +202,12 @@ func (gb *GoBuild) guessRequiredGoVersion(repoDir string) (*version.Version, boo
 		if err != nil {
 			return nil, false
 		}
-		gb.logger.Printf("found Go version %s in .go-version", requiredVersion)
 		return requiredVersion, true
 	}
+	return nil, false
+}
 
+func readGoModVersion(repoDir string) (*version.Version, bool) {
 	goModFile := filepath.Join(repoDir, "go.mod")
 	if fi, err := os.Stat(goModFile); err == nil && !fi.IsDir() {
 		b, err := os.ReadFile(goModFile)
@@ -190,9 +225,7 @@ func (gb *GoBuild) guessRequiredGoVersion(repoDir string) (*version.Version, boo
 		if err != nil {
 			return nil, false
 		}
-		gb.logger.Printf("found Go version %s in go.mod", requiredVersion)
 		return requiredVersion, true
 	}
-
 	return nil, false
 }


### PR DESCRIPTION
There is a discrepancy between a version declared in .go-version and go.mod which was recently introduced in Consul by accident.

This was surfaced as a test failure [here](https://github.com/hashicorp/hc-install/actions/runs/24241131489/job/70775820794?pr=365#step:6:113).

This ensures the `build` package still builds with the most likely correct/intended Go version even in such odd scenarios.