### PR TITLE
Parse every armored block in ArmoredPublicKey and merge by fingerprint

### DIFF
--- a/internal/releasesjson/checksum_downloader.go
+++ b/internal/releasesjson/checksum_downloader.go
@@ -194,5 +194,115 @@ func (cd *ChecksumDownloader) keyEntityList() (openpgp.EntityList, error) {
 	if cd.ArmoredPublicKey == "" {
 		return nil, fmt.Errorf("no public key provided")
 	}
-	return openpgp.ReadArmoredKeyRing(strings.NewReader(cd.ArmoredPublicKey))
+	// ArmoredPublicKey may contain more than one concatenated armored block
+	// (e.g. an original key plus a block with refreshed self-signatures).
+	// openpgp.ReadArmoredKeyRing only decodes the first block, so split the
+	// input, parse each block independently, and merge entities that share a
+	// primary key so the newest self-signatures win.
+	var entities openpgp.EntityList
+	for _, block := range splitArmoredBlocks(cd.ArmoredPublicKey) {
+		part, err := openpgp.ReadArmoredKeyRing(strings.NewReader(block))
+		if err != nil {
+			return nil, err
+		}
+		entities = append(entities, part...)
+	}
+	if len(entities) == 0 {
+		return nil, fmt.Errorf("no keys found in armored data")
+	}
+	return mergeEntitiesByPrimaryKey(entities), nil
+}
+
+// mergeEntitiesByPrimaryKey collapses entities that share a primary key into
+// one, keeping the most recent identity self-signature and subkey binding
+// signature. This lets a refreshed armored block supersede the self-signatures
+// of an older block that repeats the same primary key.
+func mergeEntitiesByPrimaryKey(entities openpgp.EntityList) openpgp.EntityList {
+	merged := make(map[string]*openpgp.Entity, len(entities))
+	order := make([]string, 0, len(entities))
+	for _, e := range entities {
+		fpr := string(e.PrimaryKey.Fingerprint)
+		existing, ok := merged[fpr]
+		if !ok {
+			merged[fpr] = e
+			order = append(order, fpr)
+			continue
+		}
+		mergeEntity(existing, e)
+	}
+	out := make(openpgp.EntityList, 0, len(order))
+	for _, fpr := range order {
+		out = append(out, merged[fpr])
+	}
+	return out
+}
+
+func mergeEntity(dst, src *openpgp.Entity) {
+	for name, srcID := range src.Identities {
+		dstID, ok := dst.Identities[name]
+		if !ok {
+			dst.Identities[name] = srcID
+			continue
+		}
+		if srcID.SelfSignature != nil &&
+			(dstID.SelfSignature == nil ||
+				srcID.SelfSignature.CreationTime.After(dstID.SelfSignature.CreationTime)) {
+			dstID.SelfSignature = srcID.SelfSignature
+		}
+		dstID.Signatures = append(dstID.Signatures, srcID.Signatures...)
+		dstID.Revocations = append(dstID.Revocations, srcID.Revocations...)
+	}
+	for _, srcSK := range src.Subkeys {
+		matched := false
+		for i := range dst.Subkeys {
+			if dst.Subkeys[i].PublicKey.KeyId != srcSK.PublicKey.KeyId {
+				continue
+			}
+			matched = true
+			if srcSK.Sig != nil &&
+				(dst.Subkeys[i].Sig == nil ||
+					srcSK.Sig.CreationTime.After(dst.Subkeys[i].Sig.CreationTime)) {
+				dst.Subkeys[i].Sig = srcSK.Sig
+			}
+			dst.Subkeys[i].Revocations = append(dst.Subkeys[i].Revocations, srcSK.Revocations...)
+			break
+		}
+		if !matched {
+			dst.Subkeys = append(dst.Subkeys, srcSK)
+		}
+	}
+	dst.Revocations = append(dst.Revocations, src.Revocations...)
+}
+
+// splitArmoredBlocks returns each ASCII-armored block in s as a separate
+// string. It tolerates leading/trailing whitespace and ignores any content
+// outside BEGIN/END markers.
+func splitArmoredBlocks(s string) []string {
+	const beginMarker = "-----BEGIN "
+	const endMarker = "-----END "
+	const endOfLine = "-----"
+
+	var blocks []string
+	for {
+		beginIdx := strings.Index(s, beginMarker)
+		if beginIdx == -1 {
+			break
+		}
+		rest := s[beginIdx:]
+		// Find the end marker after the begin.
+		endIdx := strings.Index(rest, endMarker)
+		if endIdx == -1 {
+			break
+		}
+		// Advance past the end marker line (to the next "-----" closing the line).
+		tail := rest[endIdx+len(endMarker):]
+		closeIdx := strings.Index(tail, endOfLine)
+		if closeIdx == -1 {
+			break
+		}
+		blockEnd := endIdx + len(endMarker) + closeIdx + len(endOfLine)
+		blocks = append(blocks, rest[:blockEnd])
+		s = rest[blockEnd:]
+	}
+	return blocks
 }

--- a/internal/releasesjson/checksum_downloader_test.go
+++ b/internal/releasesjson/checksum_downloader_test.go
@@ -1,0 +1,140 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package releasesjson
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/hashicorp/hc-install/internal/pubkey"
+)
+
+// Verifies that when DefaultPublicKey contains multiple concatenated armored
+// blocks sharing a primary key, keyEntityList reads all of them and keeps the
+// newest identity self-signature — letting a refreshed block extend validity
+// of the original key.
+func TestChecksumDownloader_keyEntityList_refreshedSelfSignature(t *testing.T) {
+	blocks := strings.Count(pubkey.DefaultPublicKey, "-----BEGIN PGP PUBLIC KEY BLOCK-----")
+	if blocks < 2 {
+		t.Skipf("DefaultPublicKey contains %d armored block(s); test requires >= 2", blocks)
+	}
+
+	baseline, err := openpgp.ReadArmoredKeyRing(strings.NewReader(pubkey.DefaultPublicKey))
+	if err != nil {
+		t.Fatalf("baseline ReadArmoredKeyRing: %v", err)
+	}
+	if len(baseline) != 1 {
+		t.Fatalf("baseline expected 1 entity, got %d", len(baseline))
+	}
+	baselineSelfSig := latestSelfSig(baseline[0])
+
+	cd := &ChecksumDownloader{ArmoredPublicKey: pubkey.DefaultPublicKey}
+	entities, err := cd.keyEntityList()
+	if err != nil {
+		t.Fatalf("keyEntityList: %v", err)
+	}
+	if len(entities) == 0 {
+		t.Fatal("no entities returned")
+	}
+	fixedSelfSig := latestSelfSig(entities[0])
+
+	if !fixedSelfSig.After(baselineSelfSig) {
+		t.Fatalf("expected a newer self-signature than baseline (%s); got %s",
+			baselineSelfSig, fixedSelfSig)
+	}
+}
+
+func latestSelfSig(e *openpgp.Entity) time.Time {
+	var latest time.Time
+	for _, id := range e.Identities {
+		if id.SelfSignature != nil && id.SelfSignature.CreationTime.After(latest) {
+			latest = id.SelfSignature.CreationTime
+		}
+	}
+	return latest
+}
+
+func TestChecksumDownloader_keyEntityList_empty(t *testing.T) {
+	cd := &ChecksumDownloader{}
+	if _, err := cd.keyEntityList(); err == nil {
+		t.Fatal("expected error for empty ArmoredPublicKey, got nil")
+	}
+}
+
+func TestChecksumDownloader_keyEntityList_noBlocks(t *testing.T) {
+	cd := &ChecksumDownloader{ArmoredPublicKey: "not an armored block"}
+	_, err := cd.keyEntityList()
+	if err == nil {
+		t.Fatal("expected error for input with no armored blocks, got nil")
+	}
+	if !strings.Contains(err.Error(), "no keys found") {
+		t.Fatalf("expected 'no keys found' error, got: %v", err)
+	}
+}
+
+func TestChecksumDownloader_keyEntityList_malformedBlock(t *testing.T) {
+	const malformed = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\n!!!not base64!!!\n-----END PGP PUBLIC KEY BLOCK-----"
+	cd := &ChecksumDownloader{ArmoredPublicKey: malformed}
+	if _, err := cd.keyEntityList(); err == nil {
+		t.Fatal("expected error for malformed armored block, got nil")
+	}
+}
+
+func TestSplitArmoredBlocks(t *testing.T) {
+	const blockA = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\naaaa\n-----END PGP PUBLIC KEY BLOCK-----"
+	const blockB = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nbbbb\n-----END PGP PUBLIC KEY BLOCK-----"
+
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: nil,
+		},
+		{
+			name: "single block",
+			in:   blockA,
+			want: []string{blockA},
+		},
+		{
+			name: "two blocks back to back",
+			in:   blockA + "\n" + blockB,
+			want: []string{blockA, blockB},
+		},
+		{
+			name: "leading and trailing garbage",
+			in:   "junk before\n" + blockA + "\njunk after\n",
+			want: []string{blockA},
+		},
+		{
+			name: "missing end marker",
+			in:   "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\naaaa\n",
+			want: nil,
+		},
+		{
+			name: "no begin marker",
+			in:   "just some text\nwith no armor\n",
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitArmoredBlocks(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d blocks, want %d: %q", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("block %d:\n got: %q\nwant: %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Since #355, `DefaultPublicKey` holds two concatenated armored blocks: the original key and the same primary key with refreshed self-signatures that extend validity past 2026-04-18. Two bugs together make the refresh invisible:

1. `openpgp.ReadArmoredKeyRing` decodes only the first armored block.
2. Even if both were parsed, `CheckDetachedSignature` returns on the first matching entity — the expired one — and never tries the second.

Fix: split `ArmoredPublicKey` into armored blocks, parse each, and merge entities that share a primary-key fingerprint (latest identity self-signature and subkey binding signature win; revocations accumulate). This mirrors `gpg --import` of a refreshed key and leaves single-block inputs unchanged.

Reproduction:

```
go run ./cmd/hc-install install -version 1.14.8 -path /tmp/t terraform
# before: openpgp: key expired
# after:  installed terraform@1.14.8 to /tmp/t/terraform
```

### Why here, not in go-crypto

`ReadArmoredKeyRing` reads a single armored block in both v1 and v2 of go-crypto, and there's no public keyring-merge API. Changing that upstream is a semantic change unlikely to land soon — and the two-block encoding is hc-install's choice (#355), so the fix belongs next to the code that owns it.