### PR TITLE
go.mod: Keep compatibility constraint separate from build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/hashicorp/hc-install
 
-go 1.25.8
+// Keep last digit at zero, use toolchain for Go build requirement
+go 1.25.0
+
+toolchain go1.25.8
 
 require (
 	github.com/ProtonMail/go-crypto v1.4.1


### PR DESCRIPTION
## Description

The PATCH digit - i.e. the last of the three numbers ([confusingly called "minor revisions" by Go naming convention](https://go.dev/doc/devel/release)) bumps in Go version usually represent _security_ fixes and should almost never imply breaking changes so as it require us to declare such changes a _compatibility_ constraint (which is what `go` directive does in `go.mod`).

We still need to track a specific version of Go to build against and we will continue to do so via `toolchain` directive and `.go-version` - this is also the place for bumping Go due to CVE discoveries.

Especially since this is used _primarily_ as a library, in vast majority of cases we do not need to impose a higher version of Go on our downstream consumers just because a noisy scanner is being noisy. This could be triggered by a CVE which either does not impact this library at all or one that can be fixed downstream by them pinning Go version there if downstream is so concerned or has to deal with similarly noisy scanners.

The comment should ensure this knowledge survives future Go bumps even when/if `go mod tidy` decides to wipe the `toolchain` directive.

Fixes #375

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
